### PR TITLE
rename entry-point to jsonpath_ng.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     packages=['jsonpath_ng', 'jsonpath_ng.bin', 'jsonpath_ng.ext'],
     entry_points={
         'console_scripts': [
-            'jsonpath.py=jsonpath_ng.bin.jsonpath:entry_point'
+            'jsonpath_ng.py=jsonpath_ng.bin.jsonpath:entry_point'
         ],
     },
     test_suite='tests',


### PR DESCRIPTION
conflict with this jsonpath library  : https://pypi.org/project/jsonpath/
Related to this issue [here](https://github.com/h2non/jsonpath-ng/issues/22)