### PR TITLE
Added hook for catching null value instead of empty list in path

### DIFF
--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -617,6 +617,9 @@ class Slice(JSONPath):
     def find(self, datum):
         datum = DatumInContext.wrap(datum)
 
+        # Used for catching null value instead of empty list in path
+        if not datum.value:
+            return []
         # Here's the hack. If it is a dictionary or some kind of constant,
         # put it in a single-element list
         if (isinstance(datum.value, dict) or isinstance(datum.value, six.integer_types) or isinstance(datum.value, six.string_types)):


### PR DESCRIPTION
Fixes caused by errors during parsing non-perfect JSON files with different schema.

```import json
from jsonpath_ng.ext import parse

jsonpath_expr = parse("$.store.book[*].category")

json_file = """
{
    "store": {
        "book": null,
        "bicycle": {
            "color": "red",
            "price": 19.95
        }
    },
    "expensive": 10
}
"""
result = [
    match.value for match in jsonpath_expr.find(
        json.loads(json_file)
    )
]
```
For example, after execution code block above got a TypeError:
```Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/jsonpath_ng/jsonpath.py", line 255, in find
    for subdata in self.left.find(datum)
  File "/usr/local/lib/python3.7/site-packages/jsonpath_ng/jsonpath.py", line 255, in find
    for subdata in self.left.find(datum)
  File "/usr/local/lib/python3.7/site-packages/jsonpath_ng/jsonpath.py", line 257, in <listcomp>
    for submatch in self.right.find(subdata)]
  File "/usr/local/lib/python3.7/site-packages/jsonpath_ng/jsonpath.py", line 628, in find
    return [DatumInContext(datum.value[i], path=Index(i), context=datum) for i in xrange(0, len(datum.value))]
TypeError: object of type 'NoneType' has no len()
```

