### PR TITLE
Support regular expression contains instead of 'a in b'

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -12,6 +12,7 @@
 # under the License.
 
 import operator
+import re
 from six import moves
 
 from .. import JSONPath, DatumInContext, Index
@@ -25,7 +26,7 @@ OPERATOR_MAP = {
     '<': operator.lt,
     '>=': operator.ge,
     '>': operator.gt,
-    '=~': operator.contains,
+    '=~': lambda a, b: True if re.search(b, a) else False,
 }
 
 


### PR DESCRIPTION
Use `re.search()` to check if the value being compared is contained within the filter field.

```
>>> from jsonpath_ng.ext import parse
>>> 
>>> simple_dict = {
...   "phone_numbers": [
...     {
...       "type"  : "iPhone",
...       "number": "0123-4567-8888"
...     },
...     {
...       "type"  : "home",
...       "number": "0123-4567-8910"
...     },
...     {
...       "type"  : "home",
...       "number": "1098-7654-3210"
...     }
...   ]
... }
>>> 
>>> expression = parse('$.phone_numbers[?(@.type =~ "^hom")]')
>>> 
>>> [x.value for x in expression.find(simple_dict)]
[{'type': 'home', 'number': '0123-4567-8910'}, {'type': 'home', 'number': '1098-7654-3210'}]
>>> 
>>> expression = parse('$.phone_numbers[?(@.number =~ "[0-9]{4}-4567-[0-9]{4}")]')
>>> 
>>> [x.value for x in expression.find(simple_dict)]
[{'type': 'iPhone', 'number': '0123-4567-8888'}, {'type': 'home', 'number': '0123-4567-8910'}]
``` 