### PR TITLE
support dictionary filtering

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -40,6 +40,10 @@ class Filter(JSONPath):
             return datum
 
         datum = DatumInContext.wrap(datum)
+
+        if isinstance(datum.value, dict):
+            datum.value = list(datum.value.values())
+
         if not isinstance(datum.value, list):
             return []
 


### PR DESCRIPTION
When filtering a dictionary, we can apply the filter on dictionary.values().

```
>>> from jsonpath_ng import jsonpath
>>> from jsonpath_ng.ext import parse
>>> simple_dict = {
  "phone_numbers": {
    "1":{
      "type"  : "iPhone",
      "number": "0123-4567-8888"
    },
    "2":{
      "type"  : "home",
      "number": "0123-4567-8910"
    },
    "3":{
      "type"  : "home",
      "number": "1098-7654-3210"
    }
  }
}
>>> expression = parse('$.phone_numbers[?(@.type == "home")]')
>>> print([x.value for x in expression.find(simple_dict)])
[{'type': 'home', 'number': '0123-4567-8910'}, {'type': 'home', 'number': '1098-7654-3210'}]
```
This should resolve #16 and resolve #19.
If there is any additional info I need to provide, feel free to reach out!