### PR TITLE
Exceptions

### DIFF
--- a/jsonpath_ng/exceptions.py
+++ b/jsonpath_ng/exceptions.py
@@ -1,0 +1,10 @@
+class JSONPathError(Exception):
+    pass
+
+
+class JsonPathLexerError(JSONPathError):
+    pass
+
+
+class JsonPathParserError(JSONPathError):
+    pass

--- a/jsonpath_ng/lexer.py
+++ b/jsonpath_ng/lexer.py
@@ -4,11 +4,9 @@ import logging
 
 import ply.lex
 
+from jsonpath_ng.exceptions import JsonPathLexerError
+
 logger = logging.getLogger(__name__)
-
-
-class JsonPathLexerError(Exception):
-    pass
 
 
 class JsonPathLexer(object):

--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -1,17 +1,25 @@
-from __future__ import print_function, absolute_import, division, generators, nested_scopes
+from __future__ import (
+    print_function,
+    absolute_import,
+    division,
+    generators,
+    nested_scopes,
+)
 import sys
 import os.path
-import logging
 
 import ply.yacc
 
+from jsonpath_ng.exceptions import JsonPathParserError
 from jsonpath_ng.jsonpath import *
 from jsonpath_ng.lexer import JsonPathLexer
 
 logger = logging.getLogger(__name__)
 
+
 def parse(string):
     return JsonPathParser().parse(string)
+
 
 class JsonPathParser(object):
     '''
@@ -21,8 +29,12 @@ class JsonPathParser(object):
     tokens = JsonPathLexer.tokens
 
     def __init__(self, debug=False, lexer_class=None):
-        if self.__doc__ == None:
-            raise Exception('Docstrings have been removed! By design of PLY, jsonpath-rw requires docstrings. You must not use PYTHONOPTIMIZE=2 or python -OO.')
+        if self.__doc__ is None:
+            raise JsonPathParserError(
+                'Docstrings have been removed! By design of PLY, '
+                'jsonpath-rw requires docstrings. You must not use '
+                'PYTHONOPTIMIZE=2 or python -OO.'
+            )
 
         self.debug = debug
         self.lexer_class = lexer_class or JsonPathLexer # Crufty but works around statefulness in PLY
@@ -66,7 +78,8 @@ class JsonPathParser(object):
     ]
 
     def p_error(self, t):
-        raise Exception('Parse error at %s:%s near token %s (%s)' % (t.lineno, t.col, t.value, t.type))
+        raise JsonPathParserError('Parse error at %s:%s near token %s (%s)'
+                                  % (t.lineno, t.col, t.value, t.type))
 
     def p_jsonpath_binop(self, p):
         """jsonpath : jsonpath '.' jsonpath
@@ -98,7 +111,8 @@ class JsonPathParser(object):
         elif p[1] == 'parent':
             p[0] = Parent()
         else:
-            raise Exception('Unknown named operator `%s` at %s:%s' % (p[1], p.lineno(1), p.lexpos(1)))
+            raise JsonPathParserError('Unknown named operator `%s` at %s:%s'
+                                      % (p[1], p.lineno(1), p.lexpos(1)))
 
     def p_jsonpath_root(self, p):
         "jsonpath : '$'"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,20 @@
+import pytest
+
+from jsonpath_ng import parse as rw_parse
+from jsonpath_ng.exceptions import JSONPathError, JsonPathParserError
+from jsonpath_ng.ext import parse as ext_parse
+
+
+def test_rw_exception_class():
+    with pytest.raises(JSONPathError):
+        rw_parse('foo.bar.`grandparent`.baz')
+
+
+def test_rw_exception_subclass():
+    with pytest.raises(JsonPathParserError):
+        rw_parse('foo.bar.`grandparent`.baz')
+
+
+def test_ext_exception_subclass():
+    with pytest.raises(JsonPathParserError):
+        ext_parse('foo.bar.`grandparent`.baz')


### PR DESCRIPTION
@h2non this is a small one.

In code that calls `parse()`, I have been reraising jsonpath-rw parser errors as my own Exception subclass, so I can treat parser errors differently from other exceptions. But that means catching `Exception`: Not ideal.

This pull request resolves that.