### PR TITLE
JSONPath.update() supports create

### DIFF
--- a/jsonpath_ng/exceptions.py
+++ b/jsonpath_ng/exceptions.py
@@ -1,0 +1,10 @@
+class JSONPathError(Exception):
+    pass
+
+
+class JsonPathLexerError(JSONPathError):
+    pass
+
+
+class JsonPathParserError(JSONPathError):
+    pass

--- a/jsonpath_ng/ext/arithmetic.py
+++ b/jsonpath_ng/ext/arithmetic.py
@@ -29,12 +29,12 @@ class Operation(JSONPath):
         self.op = OPERATOR_MAP[op]
         self.right = right
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         result = []
         if (isinstance(self.left, JSONPath)
                 and isinstance(self.right, JSONPath)):
-            left = self.left.find(datum)
-            right = self.right.find(datum)
+            left = self.left.find(datum, create)
+            right = self.right.find(datum, create)
             if left and right and len(left) == len(right):
                 for l, r in zip(left, right):
                     try:
@@ -44,14 +44,14 @@ class Operation(JSONPath):
             else:
                 return []
         elif isinstance(self.left, JSONPath):
-            left = self.left.find(datum)
+            left = self.left.find(datum, create)
             for l in left:
                 try:
                     result.append(self.op(l.value, self.right))
                 except TypeError:
                     return []
         elif isinstance(self.right, JSONPath):
-            right = self.right.find(datum)
+            right = self.right.find(datum, create)
             for r in right:
                 try:
                     result.append(self.op(self.left, r.value))

--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -36,7 +36,7 @@ class Filter(JSONPath):
     def __init__(self, expressions):
         self.expressions = expressions
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         if not self.expressions:
             return datum
 
@@ -51,13 +51,15 @@ class Filter(JSONPath):
         return [DatumInContext(datum.value[i], path=Index(i), context=datum)
                 for i in moves.range(0, len(datum.value))
                 if (len(self.expressions) ==
-                    len(list(filter(lambda x: x.find(datum.value[i]),
+                    len(list(filter(lambda x: x.find(datum.value[i], create),
                                     self.expressions))))]
 
-    def update(self, data, val):
+    def update(self, data, val, create=False):
         if type(data) is list:
             for index, item in enumerate(data):
-                shouldUpdate = len(self.expressions) == len(list(filter(lambda x: x.find(item), self.expressions)))
+                shouldUpdate = (len(self.expressions) ==
+                                len(list(filter(lambda x: x.find(item, create),
+                                                self.expressions))))
                 if shouldUpdate:
                     if hasattr(val, '__call__'):
                         val.__call__(data[index], data, index)
@@ -80,8 +82,8 @@ class Expression(JSONPath):
         self.op = op
         self.value = value
 
-    def find(self, datum):
-        datum = self.target.find(DatumInContext.wrap(datum))
+    def find(self, datum, create=False):
+        datum = self.target.find(DatumInContext.wrap(datum), create)
 
         if not datum:
             return []

--- a/jsonpath_ng/ext/iterable.py
+++ b/jsonpath_ng/ext/iterable.py
@@ -43,7 +43,7 @@ class SortedThis(This):
                 return -1 if reverse else 1
         return 0
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         """Return sorted value of This if list or dict."""
         if isinstance(datum.value, dict) and self.expressions:
             return datum
@@ -71,7 +71,7 @@ class Len(JSONPath):
     Concrete syntax is '`len`'.
     """
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         datum = DatumInContext.wrap(datum)
         try:
             value = len(datum.value)

--- a/jsonpath_ng/ext/string.py
+++ b/jsonpath_ng/ext/string.py
@@ -39,7 +39,7 @@ class Sub(This):
         self.regex = re.compile(self.expr)
         self.method = method
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         datum = DatumInContext.wrap(datum)
         value = self.regex.sub(self.repl, datum.value)
         if value == datum.value:
@@ -72,7 +72,7 @@ class Split(This):
         self.max_split = int(m.group(3))
         self.method = method
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         datum = DatumInContext.wrap(datum)
         try:
             value = datum.value.split(self.char, self.max_split)[self.segment]
@@ -102,7 +102,7 @@ class Str(This):
             raise DefintionInvalid("%s is not valid" % method)
         self.method = method
 
-    def find(self, datum):
+    def find(self, datum, create=False):
         datum = DatumInContext.wrap(datum)
         value = str(datum.value)
         return [DatumInContext.wrap(value)]

--- a/jsonpath_ng/lexer.py
+++ b/jsonpath_ng/lexer.py
@@ -4,11 +4,9 @@ import logging
 
 import ply.lex
 
+from jsonpath_ng.exceptions import JsonPathLexerError
+
 logger = logging.getLogger(__name__)
-
-
-class JsonPathLexerError(Exception):
-    pass
 
 
 class JsonPathLexer(object):

--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -1,17 +1,25 @@
-from __future__ import print_function, absolute_import, division, generators, nested_scopes
+from __future__ import (
+    print_function,
+    absolute_import,
+    division,
+    generators,
+    nested_scopes,
+)
 import sys
 import os.path
-import logging
 
 import ply.yacc
 
+from jsonpath_ng.exceptions import JsonPathParserError
 from jsonpath_ng.jsonpath import *
 from jsonpath_ng.lexer import JsonPathLexer
 
 logger = logging.getLogger(__name__)
 
+
 def parse(string):
     return JsonPathParser().parse(string)
+
 
 class JsonPathParser(object):
     '''
@@ -21,8 +29,12 @@ class JsonPathParser(object):
     tokens = JsonPathLexer.tokens
 
     def __init__(self, debug=False, lexer_class=None):
-        if self.__doc__ == None:
-            raise Exception('Docstrings have been removed! By design of PLY, jsonpath-rw requires docstrings. You must not use PYTHONOPTIMIZE=2 or python -OO.')
+        if self.__doc__ is None:
+            raise JsonPathParserError(
+                'Docstrings have been removed! By design of PLY, '
+                'jsonpath-rw requires docstrings. You must not use '
+                'PYTHONOPTIMIZE=2 or python -OO.'
+            )
 
         self.debug = debug
         self.lexer_class = lexer_class or JsonPathLexer # Crufty but works around statefulness in PLY
@@ -66,7 +78,8 @@ class JsonPathParser(object):
     ]
 
     def p_error(self, t):
-        raise Exception('Parse error at %s:%s near token %s (%s)' % (t.lineno, t.col, t.value, t.type))
+        raise JsonPathParserError('Parse error at %s:%s near token %s (%s)'
+                                  % (t.lineno, t.col, t.value, t.type))
 
     def p_jsonpath_binop(self, p):
         """jsonpath : jsonpath '.' jsonpath
@@ -98,7 +111,8 @@ class JsonPathParser(object):
         elif p[1] == 'parent':
             p[0] = Parent()
         else:
-            raise Exception('Unknown named operator `%s` at %s:%s' % (p[1], p.lineno(1), p.lexpos(1)))
+            raise JsonPathParserError('Unknown named operator `%s` at %s:%s'
+                                      % (p[1], p.lineno(1), p.lexpos(1)))
 
     def p_jsonpath_root(self, p):
         "jsonpath : '$'"

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+
+import pytest
+
+from jsonpath_ng.ext import parse
+
+Params = namedtuple('Params', 'string initial_data insert_val target')
+
+
+@pytest.mark.parametrize('string, initial_data, insert_val, target', [
+
+    Params(string='$.foo',
+           initial_data={},
+           insert_val=42,
+           target={'foo': 42}),
+
+    Params(string='$.foo.bar',
+           initial_data={},
+           insert_val=42,
+           target={'foo': {'bar': 42}}),
+
+    Params(string='$.foo[0]',
+           initial_data={},
+           insert_val=42,
+           target={'foo': [42]}),
+
+    Params(string='$.foo[1]',
+           initial_data={},
+           insert_val=42,
+           target={'foo': [{}, 42]}),
+
+    Params(string='$.foo[0].bar',
+           initial_data={},
+           insert_val=42,
+           target={'foo': [{'bar': 42}]}),
+
+    Params(string='$.foo[1].bar',
+           initial_data={},
+           insert_val=42,
+           target={'foo': [{}, {'bar': 42}]}),
+])
+def test_update_create(string, initial_data, insert_val, target):
+    jsonpath = parse(string)
+    result = jsonpath.update(initial_data, insert_val, create=True)
+    assert result == target

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,20 @@
+import pytest
+
+from jsonpath_ng import parse as rw_parse
+from jsonpath_ng.exceptions import JSONPathError, JsonPathParserError
+from jsonpath_ng.ext import parse as ext_parse
+
+
+def test_rw_exception_class():
+    with pytest.raises(JSONPathError):
+        rw_parse('foo.bar.`grandparent`.baz')
+
+
+def test_rw_exception_subclass():
+    with pytest.raises(JsonPathParserError):
+        rw_parse('foo.bar.`grandparent`.baz')
+
+
+def test_ext_exception_subclass():
+    with pytest.raises(JsonPathParserError):
+        ext_parse('foo.bar.`grandparent`.baz')


### PR DESCRIPTION
Currently, `JSONPath.update()` updates existing values.

This PR adds support for using `JSONPath.update()` to create new values, for the purpose of building out a JSON document. Here is an example based on tests in **tests/test_create.py**:

```python
>>> data = {}
>>> jsonpath = parse('$.name[0].text')
>>> data = jsonpath.update(data, 'Sir Michael', create=True)
>>> data
{'name': [{'text': 'Sir Michael'}]}
>>> jsonpath = parse('$.birthDate')
>>> data = jsonpath.update(data, '1943-05-05', create=True)
>>> data
{'name': [{'text': 'Sir Michael'}],
 'birthDate': '1943-05-05'}
```

Creating new items is only implemented for JSONPath subclasses that make sense for this use case. For example, using `Slice` to create many values is not supported in this change, nor is using `Filter` to create items to satisfy filter criteria (although you can still use `Filter` to select existing items).


This branch is based off the "exceptions" branch (PR #70). The last four commits are new. I have tried to break commits up logically to make them easier to review.
