### PR TITLE
Allow filtering dictionaries using entry keys

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -42,8 +42,17 @@ class Filter(JSONPath):
 
         datum = DatumInContext.wrap(datum)
 
+        # Create multiple branches to try in case of objects. As the
+        # specification is pretty lose on how to access dictionaries with
+        # square brackets, provide both options on how to process objects.
+        # The first part of the expansions allows filtering dictionaries by
+        # their value objects as implemented in
+        # https://github.com/h2non/jsonpath-ng/pull/41
+        # The second part allows filtering objects by providing their keys to
+        # filter expressions as requested in
+        # https://github.com/h2non/jsonpath-ng/issues/66
         if isinstance(datum.value, dict):
-            datum.value = list(datum.value.values())
+            datum.value = list(datum.value.values()) + [datum.value]
 
         if not isinstance(datum.value, list):
             return []

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -114,6 +114,14 @@ class Testjsonpath_ng_ext(testscenarios.WithScenarios,
             },
             target=['Bad']
         )),
+        ('filter_dict', dict(string="$.numbers[?(@.cow=='moo')]",
+                             data={'numbers': {
+                                   'foo': {'cow': 'moo'},
+                                   'bar': {'cow': 'other'}}},
+                             target=[{'cow': 'moo'}])),
+        ('filter_root_element', dict(string='$[?(@.foo=42)]',
+                                     data={"foo": 42},
+                                     target=[{"foo": 42}])),
         ('sort1', dict(string='objects[/cow]',
                        data={'objects': [{'cat': 1, 'cow': 2},
                                          {'cat': 2, 'cow': 1},
@@ -296,12 +304,6 @@ class Testjsonpath_ng_ext(testscenarios.WithScenarios,
             string='foo[?(@.baz==1)]',
             data={'foo': [{'baz': 1}, {'baz': 2}]},
             target=[{'baz': 1}],
-        )),
-
-        ('bug-#2-wrong', dict(
-            string='foo[*][?(@.baz==1)]',
-            data={'foo': [{'baz': 1}, {'baz': 2}]},
-            target=[],
         )),
 
         ('boolean-filter-true', dict(


### PR DESCRIPTION
Before this commit, it was not possible to filter on the value of
object entries based on their keys such as in the following example

Given the input

```
{"foo": 42"}
```

The JSONPath `$[?(@.foo==42)]` did not produce any results and therefore
is was only possible to access top-level dictionary entries, but not to
produce or not to produce a result at all based on the value of such a
top-level entry.

This commit implements this feature while trying to keep up all other
working path expressions known from the test cases.

Interestingly, one test case specifically tried to prevent these
semantics (at a deeper level of the document structure). This case had
to be removed to make the test suite pass again. I could not find the
underlying issue number 2 to find out why this test case existed as that
issue seems to stem from a parent of this fork from long ago. Maybe, a
resulting release should therefore receive a major version bump as this
might be understood as a breaking change.

In general, the specification is pretty lose on how square brackets and
filter expression are to be understood in the case of dictionaries, not
lists. The implementations here follows the already existing practical
approach that simply makes more expressions and intended use cases
working. However, this results in multiple paths being valid to access
the same objects and therefore an ambiguity is created.

Fixes #66