### PR TITLE
refactor(package): remove dependency for decorator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ply
-decorator
 six
 setuptools>=18.5

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     },
     test_suite='tests',
     install_requires=[
-        'ply', 'decorator', 'six'
+        'ply', 'six'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The `decorator` dependency is unused (and from a quick look at the history was never used to begin with). It can be removed.