### PR TITLE
Fix for "README.rst examples are syntactically wrong #60"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,9 +202,9 @@ Extensions
 |              | - $.objects[\\some_field,/other_field]       |
 +--------------+----------------------------------------------+
 | filter       | - $.objects[?(@some_field > 5)]              |
-|              | - $.objects[?some_field = "foobar")]         |
-|              | - $.objects[?some_field =~ "foobar")]        |
-|              | - $.objects[?some_field > 5 & other < 2)]    |
+|              | - $.objects[?(some_field = "foobar")]         |
+|              | - $.objects[?(some_field =~ "foobar")]        |
+|              | - $.objects[?(some_field > 5 & other < 2)]    |
 +--------------+----------------------------------------------+
 | arithmetic   | - $.foo + "_" + $.bar                        |
 | (-+*/)       | - $.foo * 12                                 |

--- a/README.rst
+++ b/README.rst
@@ -201,10 +201,10 @@ Extensions
 |              | - $.objects[\\some_field]                    |
 |              | - $.objects[\\some_field,/other_field]       |
 +--------------+----------------------------------------------+
-| filter       | - $.objects[?(@some_field > 5)]              |
-|              | - $.objects[?(some_field = "foobar")]         |
-|              | - $.objects[?(some_field =~ "foobar")]        |
-|              | - $.objects[?(some_field > 5 & other < 2)]    |
+| filter       | - $.objects[?(@.some_field > 5)]             |
+|              | - $.objects[?(@.some_field = "foobar")]      |
+|              | - $.objects[?(@.some_field =~ "foobar")]     |
+|              | - $.objects[?(@.some_field > 5 & other < 2)] |
 +--------------+----------------------------------------------+
 | arithmetic   | - $.foo + "_" + $.bar                        |
 | (-+*/)       | - $.foo * 12                                 |

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -570,9 +570,9 @@ class Fields(JSONPath):
     def _update_base(self, data, val, create):
         if data is not None:
             for field in self.reified_fields(DatumInContext.wrap(data)):
-                if field not in data and create:
+                if create and field not in data:
                     data[field] = {}
-                if field in data:
+                if type(data) is not bool and field in data:
                     if hasattr(val, '__call__'):
                         val(data[field], data, field)
                     else:


### PR DESCRIPTION
Simple fix.
Not sure if $.objects[?(@.some_field > 5 & other < 2)] should really be $.objects[?(@.some_field > 5 & @.other < 2)] or not. However, I do believe having '@' twice in the filter causes an error.