### PR TITLE
README.rst examples are syntactically wrong #60 Fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Extras
    will be replaced by the JSONPath to it, giving automatic unique ids
    to any piece of data. These ids will take into account any ids
    already present as well.
--  *Named operators*: Instead of using ``@`` to reference the currently
+-  *Named operators*: Instead of using ``@`` to reference the current
    object, this library uses ```this```. In general, any string
    contained in backquotes can be made to be a new operator, currently
    by extending the library.

--- a/README.rst
+++ b/README.rst
@@ -202,9 +202,9 @@ Extensions
 |              | - $.objects[\\some_field,/other_field]       |
 +--------------+----------------------------------------------+
 | filter       | - $.objects[?(@some_field > 5)]              |
-|              | - $.objects[?some_field = "foobar")]         |
-|              | - $.objects[?some_field =~ "foobar")]        |
-|              | - $.objects[?some_field > 5 & other < 2)]    |
+|              | - $.objects[?(some_field = "foobar")]         |
+|              | - $.objects[?(some_field =~ "foobar")]        |
+|              | - $.objects[?(some_field > 5 & other < 2)]    |
 +--------------+----------------------------------------------+
 | arithmetic   | - $.foo + "_" + $.bar                        |
 | (-+*/)       | - $.foo * 12                                 |

--- a/README.rst
+++ b/README.rst
@@ -201,10 +201,10 @@ Extensions
 |              | - $.objects[\\some_field]                    |
 |              | - $.objects[\\some_field,/other_field]       |
 +--------------+----------------------------------------------+
-| filter       | - $.objects[?(@some_field > 5)]              |
-|              | - $.objects[?(some_field = "foobar")]         |
-|              | - $.objects[?(some_field =~ "foobar")]        |
-|              | - $.objects[?(some_field > 5 & other < 2)]    |
+| filter       | - $.objects[?(@.some_field > 5)]             |
+|              | - $.objects[?(@.some_field = "foobar")]      |
+|              | - $.objects[?(@.some_field =~ "foobar")]     |
+|              | - $.objects[?(@.some_field > 5 & other < 2)] |
 +--------------+----------------------------------------------+
 | arithmetic   | - $.foo + "_" + $.bar                        |
 | (-+*/)       | - $.foo * 12                                 |


### PR DESCRIPTION
Reopened with "fix" branch.

Simple fix.
Not sure if $.objects[?(@.some_field > 5 & other < 2)] should really be $.objects[?(@.some_field > 5 & @.other < 2)] or not. However, I do believe having '@' twice in the filter causes an error.