### PR TITLE
always return sub value

### DIFF
--- a/jsonpath_ng/ext/string.py
+++ b/jsonpath_ng/ext/string.py
@@ -42,10 +42,7 @@ class Sub(This):
     def find(self, datum):
         datum = DatumInContext.wrap(datum)
         value = self.regex.sub(self.repl, datum.value)
-        if value == datum.value:
-            return []
-        else:
-            return [DatumInContext.wrap(value)]
+        return [DatumInContext.wrap(value)]
 
     def __eq__(self, other):
         return (isinstance(other, Sub) and self.method == other.method)


### PR DESCRIPTION
python sub method always return the original value even if there was no match and replacement. 
to be consistent with python, this PR propose to remove checking if value hasn't changed and return the original value as it as.