### PR TITLE
Fix issue with lambda based updates

### DIFF
--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -574,7 +574,7 @@ class Fields(JSONPath):
                     data[field] = {}
                 if field in data:
                     if hasattr(val, '__call__'):
-                        val(data[field], data, field)
+                        data[field] = val(data[field], data, field)
                     else:
                         data[field] = val
         return data
@@ -638,7 +638,7 @@ class Index(JSONPath):
                 data = _create_list_key(data)
             self._pad_value(data)
         if hasattr(val, '__call__'):
-            val.__call__(data[self.index], data, self.index)
+            data[self.index] = val.__call__(data[self.index], data, self.index)
         elif len(data) > self.index:
             data[self.index] = val
         return data


### PR DESCRIPTION
When performing an update with a lambda function, the lambda function is correctly detected and called but the returned value is not used.

Example:
```python
import jsonpath_ng

expr = jsonpath_ng.parse("foo[*].baz")
d = {'foo': [{'baz': 1}, {'baz': 2}]}

d = expr.update(d, lambda x, y, z: x + 1)
```

The expected value for `d` is:
```python
d = {'foo': [{'baz': 2}, {'baz': 3}]}
```
But values are not updated.