### PR TITLE
Keys removal (filter) with path filtering

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -54,6 +54,16 @@ class Filter(JSONPath):
                     len(list(filter(lambda x: x.find(datum.value[i]),
                                     self.expressions))))]
 
+    def filter(self, fn, data):
+        # NOTE: We reverse the order just to make sure the indexes are preserved upon
+        #  removal.
+        for datum in reversed(self.find(data)):
+            index_obj = datum.path
+            if isinstance(data, dict):
+                index_obj.index = list(data)[index_obj.index]
+            index_obj.filter(fn, data)
+        return data
+
     def update(self, data, val):
         if type(data) is list:
             for index, item in enumerate(data):

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -470,6 +470,14 @@ class TestJsonPath(base.BaseTestCase):
             else:
                 assert str(result.path) == target
 
+    def test_filter_with_filtering(self):
+        data = {"foos": [{"id": 1, "name": "first"}, {"id": 2, "name": "second"}]}
+        result = parser.parse('$.foos[?(@.name=="second")]').filter(
+            lambda _: True, data
+        )
+        names = [item["name"] for item in result["foos"]]
+        assert "second" not in names
+
     def test_fields_paths(self):
         jsonpath.auto_id_field = None
         self.check_paths([('foo', {'foo': 'baz'}, ['foo']),


### PR DESCRIPTION
Closes #42 

Adds support for removing keys with `.filter()` on JSON paths containing filtering.