### PR TITLE
readme formatting fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,30 +187,30 @@ Extras
 Extensions
 ----------
 
-+--------------+----------------------------------------------+
-| name         | Example                                      |
-+==============+==============================================+
-| len          | - $.objects.`len`                            |
-+--------------+----------------------------------------------+
-| sub          | - $.field.`sub(/foo\\\\+(.*)/, \\\\1)`       |
-+--------------+----------------------------------------------+
-| split        | - $.field.`split(+, 2, -1)`                  |
-|              | - $.field.`split(sep, segement, maxsplit)`   |
-+--------------+----------------------------------------------+
-| sorted       | - $.objects.`sorted`                         |
-|              | - $.objects[\\some_field]                    |
-|              | - $.objects[\\some_field,/other_field]       |
-+--------------+----------------------------------------------+
-| filter       | - $.objects[?(@some_field > 5)]              |
-|              | - $.objects[?some_field = "foobar")]         |
-|              | - $.objects[?some_field =~ "foobar")]        |
-|              | - $.objects[?some_field > 5 & other < 2)]    |
-+--------------+----------------------------------------------+
-| arithmetic   | - $.foo + "_" + $.bar                        |
-| (-+*/)       | - $.foo * 12                                 |
-|              | - $.objects[*].cow + $.objects[*].cat        |
-+--------------+----------------------------------------------+
-
++--------------+-----------------------------------------------+
+| name         | Example                                       |
++==============+===============================================+
+| len          | - ``$.objects.`len```                         |
++--------------+-----------------------------------------------+
+| sub          | - ``$.field.`sub(/foo\\\\+(.*)/, \\\\1)```    |
++--------------+-----------------------------------------------+
+| split        | - ``$.field.`split(+, 2, -1)```               |
+|              | - ``$.field.`split(sep, segement, maxsplit)```|
++--------------+-----------------------------------------------+
+| sorted       | - ``$.objects.`sorted```                      |
+|              | - ``$.objects[\\some_field]``                 |
+|              | - ``$.objects[\\some_field,/other_field]``    |
++--------------+-----------------------------------------------+
+| filter       | - ``$.objects[?(@some_field > 5)]``           |
+|              | - ``$.objects[?some_field = "foobar")]``      |
+|              | - ``$.objects[?some_field =~ "foobar")]``     |
+|              | - ``$.objects[?some_field > 5 & other < 2)]`` |
++--------------+-----------------------------------------------+
+| arithmetic   | - ``$.foo + "_" + $.bar``                     |
+| (-+*/)       | - ``$.foo * 12``                              |
+|              | - ``$.objects[*].cow + $.objects[*].cat``     |
++--------------+-----------------------------------------------+
+-
 About arithmetic and string
 ---------------------------
 
@@ -228,10 +228,10 @@ Example with data::
         'fish': 'bar'
     }
 
-| **cow + fish** returns **cowfish**
-| **$.cow + $.fish** returns **foobar**
-| **$.cow + "_" + $.fish** returns **foo_bar**
-| **$.cow + "_" + fish** returns **foo_fish**
+| ``cow + fish`` returns ``cowfish``
+| ``$.cow + $.fish`` returns ``foobar``
+| ``$.cow + "_" + $.fish`` returns ``foo_bar``
+| ``$.cow + "_" + fish`` returns ``foo_fish``
 
 About arithmetic and list
 -------------------------
@@ -245,7 +245,7 @@ Example with data::
         {'cow': 4, 'cat': 6}
     ]}
 
-| **$.objects[\*].cow + $.objects[\*].cat** returns **[6, 9]**
+| ``$.objects[\*].cow + $.objects[\*].cat`` returns ``[6, 9]``
 
 More to explore
 ---------------


### PR DESCRIPTION
Improve README formatting by using inline literals.

This also fixes some issues where `\\\\` was being shown as `\\`.

OLD:
![image](https://user-images.githubusercontent.com/249606/224990057-934a93b9-e036-417b-8942-c01fa3ae9ae1.png)

NEW:
![image](https://user-images.githubusercontent.com/249606/224990014-354a97eb-7d8b-4dbf-8a90-4c9e876d0cbe.png)
