### PR TITLE
Fix exception type on certain syntax errors

### DIFF
--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -80,6 +80,8 @@ class JsonPathParser(object):
     ]
 
     def p_error(self, t):
+        if t is None:
+            raise JsonPathParserError('Parse error near the end of string!')
         raise JsonPathParserError('Parse error at %s:%s near token %s (%s)'
                                   % (t.lineno, t.col, t.value, t.type))
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -10,11 +10,31 @@ def test_rw_exception_class():
         rw_parse('foo.bar.`grandparent`.baz')
 
 
-def test_rw_exception_subclass():
+@pytest.mark.parametrize(
+    "path",
+    (
+        'foo[*.bar.baz',
+        'foo.bar.`grandparent`.baz',
+        # error at the end of string
+        'foo[*',
+        # `len` extension not available in the base parser
+        'foo.bar.`len`',
+    )
+)
+def test_rw_exception_subclass(path):
     with pytest.raises(JsonPathParserError):
-        rw_parse('foo.bar.`grandparent`.baz')
+        rw_parse(path)
 
 
-def test_ext_exception_subclass():
+@pytest.mark.parametrize(
+    "path",
+    (
+        'foo[*.bar.baz',
+        'foo.bar.`grandparent`.baz',
+        # error at the end of string
+        'foo[*',
+    )
+)
+def test_ext_exception_subclass(path):
     with pytest.raises(JsonPathParserError):
-        ext_parse('foo.bar.`grandparent`.baz')
+        ext_parse(path)


### PR DESCRIPTION
Raise JsonPathParserError when there is a syntax error at the end of path string. Before, for example, 'foo[*' would raise an AttributeError instead.

The bug was in `p_error` method, it was assumed that it always got a token but it gets a None whenever the error is at the end of path.

See: https://ply.readthedocs.io/en/latest/ply.html?highlight=p_error#syntax-error-handling ("if the syntax error is due to reaching the end-of-file, p_error() is called with an argument of None")