### PR TITLE
Support, and test against, Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
+        allow-prereleases: true
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Escalate warnings to errors.
+    "error",
+
+    # The ply package doesn't close its debug log file. Ignore this warning.
+    "ignore::ResourceWarning",
+]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
This PR introduces the following changes:

* Test against Python 3.12 in GitHub CI
* Add Python 3.12 to the trove classifiers in `setup.py`
* Escalate warnings into errors when running the test suite

  _Escalating warnings guards against future Python language changes or programming issues that would otherwise surface in other projects' test suites._

Please let me know if you have any questions about these changes. Thanks for your work on jsonpath-ng!