### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR introduces a Dependabot config to keep GitHub action versions updated in perpetuity.

When an action used in `ci.yaml` is updated (for example, `actions/checkout@v3`, which was recently updated to `v4`), Dependabot will submit a PR to update the action version.

If this merges, Dependabot will immediately open a PR to update `actions/checkout` to `v4`, and will monitor for updates on a monthly basis. :+1: 