### PR TITLE
Fix running CI against incoming PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The current CI configuration suggests that CI should be running against incoming PRs. However, the configuration targets PRs that use `main` as their base branch, but no `main` branch currently exists.

This PR updates the configuration so CI runs against incoming PRs.
