### PR TITLE
Remove the `oslotest` dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-oslotest
 pytest
 flake8
 coverage

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -19,8 +19,9 @@ test_jsonpath_ng_ext
 Tests for `jsonpath_ng_ext` module.
 """
 
+import unittest
+
 from jsonpath_ng import jsonpath  # For setting the global auto_id_field flag
-from oslotest import base
 
 from jsonpath_ng.ext import parser
 
@@ -376,7 +377,7 @@ class Testjsonpath_ng_ext:
 # to ensure we didn't break jsonpath_ng
 
 
-class TestJsonPath(base.BaseTestCase):
+class TestJsonPath(unittest.TestCase):
     """Tests of the actual jsonpath functionality """
 
     #


### PR DESCRIPTION
The `oslotest` features are not used in the codebase.

I ran the test suite locally and all tests continue to pass.