### PR TITLE
Remove the `coveralls` dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,4 @@ oslotest
 pytest
 flake8
 coverage
-coveralls
 pytest-cov


### PR DESCRIPTION
Coveralls is not used anywhere in the project, and CI isn't configured to use it either.

The package is also outdated; removing it allows coverage to upgrade from v6 to v7.