### PR TITLE
remove Python2 crumbs

### DIFF
--- a/jsonpath_ng/bin/jsonpath.py
+++ b/jsonpath_ng/bin/jsonpath.py
@@ -5,9 +5,6 @@
 # terms of the Do What The Fuck You Want To Public License, Version 2,
 # as published by Sam Hocevar. See the COPYING file for more details.
 
-# Use modern Python
-from __future__ import unicode_literals, print_function, absolute_import
-
 # Standard Library imports
 import json
 import sys

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, generators, nested_scopes,
-                        print_function, unicode_literals)
-
 import logging
 from itertools import *  # noqa
 from jsonpath_ng.lexer import JsonPathLexer
@@ -16,7 +13,7 @@ NOT_SET = object()
 LIST_KEY = object()
 
 
-class JSONPath(object):
+class JSONPath:
     """
     The base class for JSONPath abstract syntax; those
     methods stubbed here are the interface to supported
@@ -78,7 +75,7 @@ class JSONPath(object):
             return DatumInContext(value, path=Root(), context=None)
 
 
-class DatumInContext(object):
+class DatumInContext:
     """
     Represents a datum along a path from a context.
 

--- a/jsonpath_ng/lexer.py
+++ b/jsonpath_ng/lexer.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import sys
 import logging
 
@@ -9,7 +8,7 @@ from jsonpath_ng.exceptions import JsonPathLexerError
 logger = logging.getLogger(__name__)
 
 
-class JsonPathLexer(object):
+class JsonPathLexer:
     '''
     A Lexical analyzer for JsonPath.
     '''

--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    print_function,
-    absolute_import,
-    division,
-    generators,
-    nested_scopes,
-)
 import logging
 import sys
 import os.path
@@ -22,7 +15,7 @@ def parse(string):
     return JsonPathParser().parse(string)
 
 
-class JsonPathParser(object):
+class JsonPathParser:
     '''
     An LALR-parser for JsonPath
     '''
@@ -189,7 +182,7 @@ class JsonPathParser(object):
         'empty :'
         p[0] = None
 
-class IteratorToTokenStream(object):
+class IteratorToTokenStream:
     def __init__(self, iterator):
         self.iterator = iterator
 

--- a/tests/bin/__init__.py
+++ b/tests/bin/__init__.py
@@ -1,2 +1,0 @@
-# Use modern python
-from __future__ import absolute_import, print_function, unicode_literals

--- a/tests/bin/test_jsonpath.py
+++ b/tests/bin/test_jsonpath.py
@@ -1,6 +1,3 @@
-# Use modern Python
-from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
-
 # Standard library imports
 import unittest
 import logging
@@ -15,7 +12,7 @@ class TestJsonPathScript(unittest.TestCase):
     """
     Tests for the jsonpath.py command line interface.
     """
-    
+
     @classmethod
     def setup_class(cls):
         logging.basicConfig()

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import unittest
 
 from jsonpath_ng import jsonpath # For setting the global auto_id_field flag

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import logging
 import unittest
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 import unittest
 
 from jsonpath_ng.lexer import JsonPathLexer


### PR DESCRIPTION
I noticed the removal of `six`.

This old Python2 compat code can go too.

All of these optional future feature are now mandatoy: https://docs.python.org/3/library/__future__.html