### PR TITLE
Update tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 flake8
 coverage
 pytest-cov
+pytest-randomly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_auto_id_field(monkeypatch):
+    monkeypatch.setattr("jsonpath_ng.jsonpath.auto_id_field", None)
+
+
+@pytest.fixture()
+def auto_id_field(monkeypatch, disable_auto_id_field):
+    """Enable `jsonpath_ng.jsonpath.auto_id_field`."""
+
+    field_name = "id"
+    monkeypatch.setattr("jsonpath_ng.jsonpath.auto_id_field", field_name)
+    return field_name

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,38 @@
+def assert_value_equality(results, expected_values):
+    """Assert equality between two objects.
+
+    *results* must be a list of results as returned by `.find()` methods.
+
+    If *expected_values* is a list, then value equality and ordering will be checked.
+    If *expected_values* is a set, value equality and container length will be checked.
+    Otherwise, the value of the results will be compared to the expected values.
+    """
+
+    left_values = [result.value for result in results]
+    if isinstance(expected_values, list):
+        assert left_values == expected_values
+    elif isinstance(expected_values, set):
+        assert len(left_values) == len(expected_values)
+        assert set(left_values) == expected_values
+    else:
+        assert results.value == expected_values
+
+
+def assert_full_path_equality(results, expected_full_paths):
+    """Assert equality between two objects.
+
+    *results* must be a list of results as returned by `.find()` methods.
+
+    If *expected_full_paths* is a list, then path equality and ordering will be checked.
+    If *expected_full_paths* is a set, then path equality and length will be checked.
+    Otherwise, the full path of the result will be compared to the expected full path.
+    """
+
+    full_paths = [str(result.full_path) for result in results]
+    if isinstance(expected_full_paths, list):
+        assert full_paths == expected_full_paths, full_paths
+    elif isinstance(expected_full_paths, set):
+        assert len(full_paths) == len(expected_full_paths)
+        assert set(full_paths) == expected_full_paths
+    else:
+        assert str(results.full_path) == expected_full_paths

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,18 +21,15 @@ def assert_value_equality(results, expected_values):
 def assert_full_path_equality(results, expected_full_paths):
     """Assert equality between two objects.
 
-    *results* must be a list of results as returned by `.find()` methods.
+    *results* must be a list or set of results as returned by `.find()` methods.
 
     If *expected_full_paths* is a list, then path equality and ordering will be checked.
     If *expected_full_paths* is a set, then path equality and length will be checked.
-    Otherwise, the full path of the result will be compared to the expected full path.
     """
 
     full_paths = [str(result.full_path) for result in results]
     if isinstance(expected_full_paths, list):
         assert full_paths == expected_full_paths, full_paths
-    elif isinstance(expected_full_paths, set):
+    else:  # isinstance(expected_full_paths, set):
         assert len(full_paths) == len(expected_full_paths)
         assert set(full_paths) == expected_full_paths
-    else:
-        assert str(results.full_path) == expected_full_paths

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,7 @@ def assert_value_equality(results, expected_values):
         assert len(left_values) == len(expected_values)
         assert set(left_values) == expected_values
     else:
-        assert results.value == expected_values
+        assert results[0].value == expected_values
 
 
 def assert_full_path_equality(results, expected_full_paths):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,55 +1,67 @@
 import pytest
 
-from jsonpath_ng.ext.filter import Filter, Expression
 from jsonpath_ng.ext import parse
-from jsonpath_ng.jsonpath import *
+from jsonpath_ng.ext.filter import Expression, Filter
+from jsonpath_ng.jsonpath import Child, Descendants, Fields, Index, Root, Slice, This
 
 
-@pytest.mark.parametrize('string, parsed', [
-    # The authors of all books in the store
-    ("$.store.book[*].author",
-     Child(Child(Child(Child(Root(), Fields('store')), Fields('book')),
-                 Slice()), Fields('author'))),
-
-    # All authors
-    ("$..author", Descendants(Root(), Fields('author'))),
-
-    # All things in the store
-    ("$.store.*", Child(Child(Root(), Fields('store')), Fields('*'))),
-
-    # The price of everything in the store
-    ("$.store..price",
-     Descendants(Child(Root(), Fields('store')), Fields('price'))),
-
-    # The third book
-    ("$..book[2]",
-     Child(Descendants(Root(), Fields('book')),Index(2))),
-
-    # The last book in order
-    # ("$..book[(@.length-1)]",  # Not implemented
-    #  Child(Descendants(Root(), Fields('book')), Slice(start=-1))),
-    ("$..book[-1:]",
-     Child(Descendants(Root(), Fields('book')), Slice(start=-1))),
-
-    # The first two books
-    # ("$..book[0,1]",  # Not implemented
-    #  Child(Descendants(Root(), Fields('book')), Slice(end=2))),
-    ("$..book[:2]",
-     Child(Descendants(Root(), Fields('book')), Slice(end=2))),
-
-    # Filter all books with ISBN number
-    ("$..book[?(@.isbn)]",
-     Child(Descendants(Root(), Fields('book')),
-           Filter([Expression(Child(This(), Fields('isbn')), None, None)]))),
-
-    # Filter all books cheaper than 10
-    ("$..book[?(@.price<10)]",
-     Child(Descendants(Root(), Fields('book')),
-           Filter([Expression(Child(This(), Fields('price')), '<', 10)]))),
-
-    # All members of JSON structure
-    ("$..*", Descendants(Root(), Fields('*'))),
-])
+@pytest.mark.parametrize(
+    "string, parsed",
+    [
+        # The authors of all books in the store
+        (
+            "$.store.book[*].author",
+            Child(
+                Child(Child(Child(Root(), Fields("store")), Fields("book")), Slice()),
+                Fields("author"),
+            ),
+        ),
+        #
+        # All authors
+        ("$..author", Descendants(Root(), Fields("author"))),
+        #
+        # All things in the store
+        ("$.store.*", Child(Child(Root(), Fields("store")), Fields("*"))),
+        #
+        # The price of everything in the store
+        (
+            "$.store..price",
+            Descendants(Child(Root(), Fields("store")), Fields("price")),
+        ),
+        #
+        # The third book
+        ("$..book[2]", Child(Descendants(Root(), Fields("book")), Index(2))),
+        #
+        # The last book in order
+        # "$..book[(@.length-1)]"  # Not implemented
+        ("$..book[-1:]", Child(Descendants(Root(), Fields("book")), Slice(start=-1))),
+        #
+        # The first two books
+        # "$..book[0,1]"  # Not implemented
+        ("$..book[:2]", Child(Descendants(Root(), Fields("book")), Slice(end=2))),
+        #
+        # Filter all books with an ISBN
+        (
+            "$..book[?(@.isbn)]",
+            Child(
+                Descendants(Root(), Fields("book")),
+                Filter([Expression(Child(This(), Fields("isbn")), None, None)]),
+            ),
+        ),
+        #
+        # Filter all books cheaper than 10
+        (
+            "$..book[?(@.price<10)]",
+            Child(
+                Descendants(Root(), Fields("book")),
+                Filter([Expression(Child(This(), Fields("price")), "<", 10)]),
+            ),
+        ),
+        #
+        # All members of JSON structure
+        ("$..*", Descendants(Root(), Fields("*"))),
+    ],
+)
 def test_goessner_examples(string, parsed):
     """
     Test Stefan Goessner's `examples`_
@@ -59,16 +71,7 @@ def test_goessner_examples(string, parsed):
     assert parse(string, debug=True) == parsed
 
 
-@pytest.mark.parametrize('string, parsed', [
-    # Navigate objects
-    ("$.store.book[0].title",
-     Child(Child(Child(Child(Root(), Fields('store')), Fields('book')),
-                 Index(0)), Fields('title'))),
+def test_attribute_and_dict_syntax():
+    """Verify that attribute and dict syntax result in identical parse trees."""
 
-    # Navigate dictionaries
-    ("$['store']['book'][0]['title']",
-     Child(Child(Child(Child(Root(), Fields('store')), Fields('book')),
-                 Index(0)), Fields('title'))),
-])
-def test_obj_v_dict(string, parsed):
-    assert parse(string, debug=True) == parsed
+    assert parse("$.store.book[0].title") == parse("$['store']['book'][0]['title']")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,11 +5,6 @@ from jsonpath_ng.exceptions import JSONPathError, JsonPathParserError
 from jsonpath_ng.ext import parse as ext_parse
 
 
-def test_rw_exception_class():
-    with pytest.raises(JSONPathError):
-        rw_parse('foo.bar.`grandparent`.baz')
-
-
 @pytest.mark.parametrize(
     "path",
     (

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,34 +1,32 @@
 import pytest
 
-from jsonpath_ng import parse as rw_parse
-from jsonpath_ng.exceptions import JSONPathError, JsonPathParserError
+from jsonpath_ng import parse as base_parse
+from jsonpath_ng.exceptions import JsonPathParserError
 from jsonpath_ng.ext import parse as ext_parse
 
 
 @pytest.mark.parametrize(
     "path",
     (
-        'foo[*.bar.baz',
-        'foo.bar.`grandparent`.baz',
-        # error at the end of string
-        'foo[*',
+        "foo[*.bar.baz",
+        "foo.bar.`grandparent`.baz",
+        "foo[*",
         # `len` extension not available in the base parser
-        'foo.bar.`len`',
-    )
+        "foo.bar.`len`",
+    ),
 )
 def test_rw_exception_subclass(path):
     with pytest.raises(JsonPathParserError):
-        rw_parse(path)
+        base_parse(path)
 
 
 @pytest.mark.parametrize(
     "path",
     (
-        'foo[*.bar.baz',
-        'foo.bar.`grandparent`.baz',
-        # error at the end of string
-        'foo[*',
-    )
+        "foo[*.bar.baz",
+        "foo.bar.`grandparent`.baz",
+        "foo[*",
+    ),
 )
 def test_ext_exception_subclass(path):
     with pytest.raises(JsonPathParserError):

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -19,15 +19,18 @@ test_jsonpath_ng_ext
 Tests for `jsonpath_ng_ext` module.
 """
 
-import unittest
-
 from jsonpath_ng import jsonpath  # For setting the global auto_id_field flag
 
 from jsonpath_ng.ext import parser
+from jsonpath_ng.exceptions import JsonPathParserError
+
+import pytest
 
 
 # Example from https://docs.pytest.org/en/7.1.x/example/parametrize.html#a-quick-port-of-testscenarios
 def pytest_generate_tests(metafunc):
+    if metafunc.cls is None:
+        return
     idlist = []
     argvalues = []
     for scenario in metafunc.cls.scenarios:
@@ -373,243 +376,10 @@ class Testjsonpath_ng_ext:
         else:
             assert target == result[0].value
 
-# NOTE(sileht): copy of tests/test_jsonpath.py
-# to ensure we didn't break jsonpath_ng
 
-
-class TestJsonPath(unittest.TestCase):
-    """Tests of the actual jsonpath functionality """
-
-    #
-    # Check that the data value returned is good
-    #
-    def check_cases(self, test_cases):
-        # Note that just manually building an AST would avoid this dep and
-        # isolate the tests, but that would suck a bit
-        # Also, we coerce iterables, etc, into the desired target type
-
-        for string, data, target in test_cases:
-            print('parse("%s").find(%s) =?= %s' % (string, data, target))
-            result = parser.parse(string).find(data)
-            if isinstance(target, list):
-                assert [r.value for r in result] == target
-            elif isinstance(target, set):
-                assert set([r.value for r in result]) == target
-            else:
-                assert result.value == target
-
-    def test_fields_value(self):
-        jsonpath.auto_id_field = None
-        self.check_cases([('foo', {'foo': 'baz'}, ['baz']),
-                          ('foo,baz', {'foo': 1, 'baz': 2}, [1, 2]),
-                          ('@foo', {'@foo': 1}, [1]),
-                          ('*', {'foo': 1, 'baz': 2}, set([1, 2]))])
-
-        jsonpath.auto_id_field = 'id'
-        self.check_cases([('*', {'foo': 1, 'baz': 2}, set([1, 2, '`this`']))])
-
-    def test_root_value(self):
-        jsonpath.auto_id_field = None
-        self.check_cases([
-            ('$', {'foo': 'baz'}, [{'foo': 'baz'}]),
-            ('foo.$', {'foo': 'baz'}, [{'foo': 'baz'}]),
-            ('foo.$.foo', {'foo': 'baz'}, ['baz']),
-        ])
-
-    def test_this_value(self):
-        jsonpath.auto_id_field = None
-        self.check_cases([
-            ('`this`', {'foo': 'baz'}, [{'foo': 'baz'}]),
-            ('foo.`this`', {'foo': 'baz'}, ['baz']),
-            ('foo.`this`.baz', {'foo': {'baz': 3}}, [3]),
-        ])
-
-    def test_index_value(self):
-        self.check_cases([
-            ('[0]', [42], [42]),
-            ('[5]', [42], []),
-            ('[2]', [34, 65, 29, 59], [29])
-        ])
-
-    def test_slice_value(self):
-        self.check_cases([('[*]', [1, 2, 3], [1, 2, 3]),
-                          ('[*]', range(1, 4), [1, 2, 3]),
-                          ('[1:]', [1, 2, 3, 4], [2, 3, 4]),
-                          ('[:2]', [1, 2, 3, 4], [1, 2])])
-
-        # Funky slice hacks
-        self.check_cases([
-            ('[*]', 1, [1]),  # This is a funky hack
-            ('[0:]', 1, [1]),  # This is a funky hack
-            ('[*]', {'foo': 1}, [{'foo': 1}]),  # This is a funky hack
-            ('[*].foo', {'foo': 1}, [1]),  # This is a funky hack
-        ])
-
-    def test_child_value(self):
-        self.check_cases([('foo.baz', {'foo': {'baz': 3}}, [3]),
-                          ('foo.baz', {'foo': {'baz': [3]}}, [[3]]),
-                          ('foo.baz.bizzle', {'foo': {'baz': {'bizzle': 5}}},
-                           [5])])
-
-    def test_descendants_value(self):
-        self.check_cases([
-            ('foo..baz', {'foo': {'baz': 1, 'bing': {'baz': 2}}}, [1, 2]),
-            ('foo..baz', {'foo': [{'baz': 1}, {'baz': 2}]}, [1, 2]),
-        ])
-
-    def test_parent_value(self):
-        self.check_cases([('foo.baz.`parent`', {'foo': {'baz': 3}},
-                           [{'baz': 3}]),
-                          ('foo.`parent`.foo.baz.`parent`.baz.bizzle',
-                           {'foo': {'baz': {'bizzle': 5}}}, [5])])
-
-    def test_hyphen_key(self):
-        # NOTE(sileht): hyphen is now a operator
-        # so to use it has key we must escape it with quote
-        # self.check_cases([('foo.bar-baz', {'foo': {'bar-baz': 3}}, [3]),
-        #                  ('foo.[bar-baz,blah-blah]',
-        #                   {'foo': {'bar-baz': 3, 'blah-blah': 5}},
-        #                   [3, 5])])
-        self.check_cases([('foo."bar-baz"', {'foo': {'bar-baz': 3}}, [3]),
-                          ('foo.["bar-baz","blah-blah"]',
-                           {'foo': {'bar-baz': 3, 'blah-blah': 5}},
-                           [3, 5])])
-        # self.assertRaises(lexer.JsonPathLexerError, self.check_cases,
-        #                  [('foo.-baz', {'foo': {'-baz': 8}}, [8])])
-
-    #
-    # Check that the paths for the data are correct.
-    # FIXME: merge these tests with the above, since the inputs are the same
-    # anyhow
-    #
-    def check_paths(self, test_cases):
-        # Note that just manually building an AST would avoid this dep and
-        # isolate the tests, but that would suck a bit
-        # Also, we coerce iterables, etc, into the desired target type
-
-        for string, data, target in test_cases:
-            print('parse("%s").find(%s).paths =?= %s' % (string, data, target))
-            result = parser.parse(string).find(data)
-            if isinstance(target, list):
-                assert [str(r.full_path) for r in result] == target
-            elif isinstance(target, set):
-                assert set([str(r.full_path) for r in result]) == target
-            else:
-                assert str(result.path) == target
-
-    def test_filter_with_filtering(self):
-        data = {"foos": [{"id": 1, "name": "first"}, {"id": 2, "name": "second"}]}
-        result = parser.parse('$.foos[?(@.name=="second")]').filter(
-            lambda _: True, data
-        )
-        names = [item["name"] for item in result["foos"]]
-        assert "second" not in names
-
-    def test_fields_paths(self):
-        jsonpath.auto_id_field = None
-        self.check_paths([('foo', {'foo': 'baz'}, ['foo']),
-                          ('foo,baz', {'foo': 1, 'baz': 2}, ['foo', 'baz']),
-                          ('*', {'foo': 1, 'baz': 2}, set(['foo', 'baz']))])
-
-        jsonpath.auto_id_field = 'id'
-        self.check_paths([('*', {'foo': 1, 'baz': 2},
-                           set(['foo', 'baz', 'id']))])
-
-    def test_root_paths(self):
-        jsonpath.auto_id_field = None
-        self.check_paths([
-            ('$', {'foo': 'baz'}, ['$']),
-            ('foo.$', {'foo': 'baz'}, ['$']),
-            ('foo.$.foo', {'foo': 'baz'}, ['foo']),
-        ])
-
-    def test_this_paths(self):
-        jsonpath.auto_id_field = None
-        self.check_paths([
-            ('`this`', {'foo': 'baz'}, ['`this`']),
-            ('foo.`this`', {'foo': 'baz'}, ['foo']),
-            ('foo.`this`.baz', {'foo': {'baz': 3}}, ['foo.baz']),
-        ])
-
-    def test_index_paths(self):
-        self.check_paths([('[0]', [42], ['[0]']),
-                          ('[2]', [34, 65, 29, 59], ['[2]'])])
-
-    def test_slice_paths(self):
-        self.check_paths([('[*]', [1, 2, 3], ['[0]', '[1]', '[2]']),
-                          ('[1:]', [1, 2, 3, 4], ['[1]', '[2]', '[3]'])])
-
-    def test_child_paths(self):
-        self.check_paths([('foo.baz', {'foo': {'baz': 3}}, ['foo.baz']),
-                          ('foo.baz', {'foo': {'baz': [3]}}, ['foo.baz']),
-                          ('foo.baz.bizzle', {'foo': {'baz': {'bizzle': 5}}},
-                           ['foo.baz.bizzle'])])
-
-    def test_descendants_paths(self):
-        self.check_paths([('foo..baz', {'foo': {'baz': 1, 'bing': {'baz': 2}}},
-                           ['foo.baz', 'foo.bing.baz'])])
-
-    #
-    # Check the "auto_id_field" feature
-    #
-    def test_fields_auto_id(self):
-        jsonpath.auto_id_field = "id"
-        self.check_cases([('foo.id', {'foo': 'baz'}, ['foo']),
-                          ('foo.id', {'foo': {'id': 'baz'}}, ['baz']),
-                          ('foo,baz.id', {'foo': 1, 'baz': 2}, ['foo', 'baz']),
-                          ('*.id',
-                           {'foo': {'id': 1},
-                            'baz': 2},
-                           set(['1', 'baz']))])
-
-    def test_root_auto_id(self):
-        jsonpath.auto_id_field = 'id'
-        self.check_cases([
-            ('$.id', {'foo': 'baz'}, ['$']),  # This is a wonky case that is
-                                              # not that interesting
-            ('foo.$.id', {'foo': 'baz', 'id': 'bizzle'}, ['bizzle']),
-            ('foo.$.baz.id', {'foo': 4, 'baz': 3}, ['baz']),
-        ])
-
-    def test_this_auto_id(self):
-        jsonpath.auto_id_field = 'id'
-        self.check_cases([
-            ('id', {'foo': 'baz'}, ['`this`']),  # This is, again, a wonky case
-                                                 # that is not that interesting
-            ('foo.`this`.id', {'foo': 'baz'}, ['foo']),
-            ('foo.`this`.baz.id', {'foo': {'baz': 3}}, ['foo.baz']),
-        ])
-
-    def test_index_auto_id(self):
-        jsonpath.auto_id_field = "id"
-        self.check_cases([('[0].id', [42], ['[0]']),
-                          ('[2].id', [34, 65, 29, 59], ['[2]'])])
-
-    def test_slice_auto_id(self):
-        jsonpath.auto_id_field = "id"
-        self.check_cases([('[*].id', [1, 2, 3], ['[0]', '[1]', '[2]']),
-                          ('[1:].id', [1, 2, 3, 4], ['[1]', '[2]', '[3]'])])
-
-    def test_child_auto_id(self):
-        jsonpath.auto_id_field = "id"
-        self.check_cases([('foo.baz.id', {'foo': {'baz': 3}}, ['foo.baz']),
-                          ('foo.baz.id', {'foo': {'baz': [3]}}, ['foo.baz']),
-                          ('foo.baz.id', {'foo': {'id': 'bizzle', 'baz': 3}},
-                           ['bizzle.baz']),
-                          ('foo.baz.id', {'foo': {'baz': {'id': 'hi'}}},
-                           ['foo.hi']),
-                          ('foo.baz.bizzle.id',
-                           {'foo': {'baz': {'bizzle': 5}}},
-                           ['foo.baz.bizzle'])])
-
-    def test_descendants_auto_id(self):
-        jsonpath.auto_id_field = "id"
-        self.check_cases([('foo..baz.id',
-                           {'foo': {
-                               'baz': 1,
-                               'bing': {
-                                   'baz': 2
-                               }
-                           }},
-                           ['foo.baz',
-                            'foo.bing.baz'])])
+def test_invalid_hyphenation_in_key():
+    # This test is almost copied-and-pasted directly from `test_jsonpath.py`.
+    # However, the parsers generate different exceptions for this syntax error.
+    # This discrepancy needs to be resolved.
+    with pytest.raises(JsonPathParserError):
+        parser.parse("foo.-baz")

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,68 +1,55 @@
-import logging
-import unittest
-
-from ply.lex import LexToken
+import pytest
 
 from jsonpath_ng.lexer import JsonPathLexer, JsonPathLexerError
 
-class TestLexer(unittest.TestCase):
+token_test_cases = (
+    ("$", (("$", "$"),)),
+    ('"hello"', (("hello", "ID"),)),
+    ("'goodbye'", (("goodbye", "ID"),)),
+    ("'doublequote\"'", (('doublequote"', "ID"),)),
+    (r'"doublequote\""', (('doublequote"', "ID"),)),
+    (r"'singlequote\''", (("singlequote'", "ID"),)),
+    ('"singlequote\'"', (("singlequote'", "ID"),)),
+    ("fuzz", (("fuzz", "ID"),)),
+    ("1", ((1, "NUMBER"),)),
+    ("45", ((45, "NUMBER"),)),
+    ("-1", ((-1, "NUMBER"),)),
+    (" -13 ", ((-13, "NUMBER"),)),
+    ('"fuzz.bang"', (("fuzz.bang", "ID"),)),
+    ("fuzz.bang", (("fuzz", "ID"), (".", "."), ("bang", "ID"))),
+    ("fuzz.*", (("fuzz", "ID"), (".", "."), ("*", "*"))),
+    ("fuzz..bang", (("fuzz", "ID"), ("..", "DOUBLEDOT"), ("bang", "ID"))),
+    ("&", (("&", "&"),)),
+    ("@", (("@", "ID"),)),
+    ("`this`", (("this", "NAMED_OPERATOR"),)),
+    ("|", (("|", "|"),)),
+    ("where", (("where", "WHERE"),)),
+)
 
-    def token(self, value, ty=None):
-        t = LexToken()
-        t.type = ty if ty != None else value
-        t.value = value
-        t.lineno = -1
-        t.lexpos = -1
-        return t
 
-    def assert_lex_equiv(self, s, stream2):
-        # NOTE: lexer fails to reset after call?
-        l = JsonPathLexer(debug=True)
-        stream1 = list(l.tokenize(s)) # Save the stream for debug output when a test fails
-        stream2 = list(stream2)
-        assert len(stream1) == len(stream2)
-        for token1, token2 in zip(stream1, stream2):
-            print(token1, token2)
-            assert token1.type  == token2.type
-            assert token1.value == token2.value
+@pytest.mark.parametrize("string, expected_token_info", token_test_cases)
+def test_lexer(string, expected_token_info):
+    lexer = JsonPathLexer(debug=True)
+    tokens = list(lexer.tokenize(string))
+    assert len(tokens) == len(expected_token_info)
+    for token, (expected_value, expected_type) in zip(tokens, expected_token_info):
+        assert token.type == expected_type
+        assert token.value == expected_value
 
-    @classmethod
-    def setup_class(cls):
-        logging.basicConfig()
 
-    def test_simple_inputs(self):
-        self.assert_lex_equiv('$', [self.token('$', '$')])
-        self.assert_lex_equiv('"hello"', [self.token('hello', 'ID')])
-        self.assert_lex_equiv("'goodbye'", [self.token('goodbye', 'ID')])
-        self.assert_lex_equiv("'doublequote\"'", [self.token('doublequote"', 'ID')])
-        self.assert_lex_equiv(r'"doublequote\""', [self.token('doublequote"', 'ID')])
-        self.assert_lex_equiv(r"'singlequote\''", [self.token("singlequote'", 'ID')])
-        self.assert_lex_equiv('"singlequote\'"', [self.token("singlequote'", 'ID')])
-        self.assert_lex_equiv('fuzz', [self.token('fuzz', 'ID')])
-        self.assert_lex_equiv('1', [self.token(1, 'NUMBER')])
-        self.assert_lex_equiv('45', [self.token(45, 'NUMBER')])
-        self.assert_lex_equiv('-1', [self.token(-1, 'NUMBER')])
-        self.assert_lex_equiv(' -13 ', [self.token(-13, 'NUMBER')])
-        self.assert_lex_equiv('"fuzz.bang"', [self.token('fuzz.bang', 'ID')])
-        self.assert_lex_equiv('fuzz.bang', [self.token('fuzz', 'ID'), self.token('.', '.'), self.token('bang', 'ID')])
-        self.assert_lex_equiv('fuzz.*', [self.token('fuzz', 'ID'), self.token('.', '.'), self.token('*', '*')])
-        self.assert_lex_equiv('fuzz..bang', [self.token('fuzz', 'ID'), self.token('..', 'DOUBLEDOT'), self.token('bang', 'ID')])
-        self.assert_lex_equiv('&', [self.token('&', '&')])
-        self.assert_lex_equiv('@', [self.token('@', 'ID')])
-        self.assert_lex_equiv('`this`', [self.token('this', 'NAMED_OPERATOR')])
-        self.assert_lex_equiv('|', [self.token('|', '|')])
-        self.assert_lex_equiv('where', [self.token('where', 'WHERE')])
+invalid_token_test_cases = (
+    "'\"",
+    "\"'",
+    '`"',
+    "`'",
+    '"`',
+    "'`",
+    "?",
+    "$.foo.bar.#",
+)
 
-    def test_basic_errors(self):
-        def tokenize(s):
-            l = JsonPathLexer(debug=True)
-            return list(l.tokenize(s))
 
-        self.assertRaises(JsonPathLexerError, tokenize, "'\"")
-        self.assertRaises(JsonPathLexerError, tokenize, '"\'')
-        self.assertRaises(JsonPathLexerError, tokenize, '`"')
-        self.assertRaises(JsonPathLexerError, tokenize, "`'")
-        self.assertRaises(JsonPathLexerError, tokenize, '"`')
-        self.assertRaises(JsonPathLexerError, tokenize, "'`")
-        self.assertRaises(JsonPathLexerError, tokenize, '?')
-        self.assertRaises(JsonPathLexerError, tokenize, '$.foo.bar.#')
+@pytest.mark.parametrize("string", invalid_token_test_cases)
+def test_lexer_errors(string):
+    with pytest.raises(JsonPathLexerError):
+        list(JsonPathLexer().tokenize(string))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,39 +1,38 @@
-import unittest
+import pytest
 
+from jsonpath_ng.jsonpath import Child, Descendants, Fields, Index, Slice, Where
 from jsonpath_ng.lexer import JsonPathLexer
 from jsonpath_ng.parser import JsonPathParser
-from jsonpath_ng.jsonpath import *
 
-class TestParser(unittest.TestCase):
-    # TODO: This will be much more effective with a few regression tests and `arbitrary` parse . pretty testing
+# Format: (string, expected_object)
+parser_test_cases = (
+    #
+    # Atomic
+    # ------
+    #
+    ("foo", Fields("foo")),
+    ("*", Fields("*")),
+    ("baz,bizzle", Fields("baz", "bizzle")),
+    ("[1]", Index(1)),
+    ("[1:]", Slice(start=1)),
+    ("[:]", Slice()),
+    ("[*]", Slice()),
+    ("[:2]", Slice(end=2)),
+    ("[1:2]", Slice(start=1, end=2)),
+    ("[5:-2]", Slice(start=5, end=-2)),
+    #
+    # Nested
+    # ------
+    #
+    ("foo.baz", Child(Fields("foo"), Fields("baz"))),
+    ("foo.baz,bizzle", Child(Fields("foo"), Fields("baz", "bizzle"))),
+    ("foo where baz", Where(Fields("foo"), Fields("baz"))),
+    ("foo..baz", Descendants(Fields("foo"), Fields("baz"))),
+    ("foo..baz.bing", Descendants(Fields("foo"), Child(Fields("baz"), Fields("bing")))),
+)
 
-    @classmethod
-    def setup_class(cls):
-        logging.basicConfig()
 
-    def check_parse_cases(self, test_cases):
-        parser = JsonPathParser(debug=True, lexer_class=lambda:JsonPathLexer(debug=False)) # Note that just manually passing token streams avoids this dep, but that sucks
-
-        for string, parsed in test_cases:
-            print(string, '=?=', parsed) # pytest captures this and we see it only on a failure, for debugging
-            assert parser.parse(string) == parsed
-
-    def test_atomic(self):
-        self.check_parse_cases([('foo', Fields('foo')),
-                                ('*', Fields('*')),
-                                ('baz,bizzle', Fields('baz','bizzle')),
-                                ('[1]', Index(1)),
-                                ('[1:]', Slice(start=1)),
-                                ('[:]', Slice()),
-                                ('[*]', Slice()),
-                                ('[:2]', Slice(end=2)),
-                                ('[1:2]', Slice(start=1, end=2)),
-                                ('[5:-2]', Slice(start=5, end=-2))
-                               ])
-
-    def test_nested(self):
-        self.check_parse_cases([('foo.baz', Child(Fields('foo'), Fields('baz'))),
-                                ('foo.baz,bizzle', Child(Fields('foo'), Fields('baz', 'bizzle'))),
-                                ('foo where baz', Where(Fields('foo'), Fields('baz'))),
-                                ('foo..baz', Descendants(Fields('foo'), Fields('baz'))),
-                                ('foo..baz.bing', Descendants(Fields('foo'), Child(Fields('baz'), Fields('bing'))))])
+@pytest.mark.parametrize("string, expected_object", parser_test_cases)
+def test_parser(string, expected_object):
+    parser = JsonPathParser(lexer_class=lambda: JsonPathLexer())
+    assert parser.parse(string) == expected_object


### PR DESCRIPTION
This PR overhauls the test suite in several ways:

* All tests are parametrized where possible -- tests no longer use `for` loops.

  This has resulted in a jump in test visibility from 171 tests to 307 tests.
* The `jsonpath_ng` and `jsonpath_ng.ext` parsers are now tested in lock step -- inconsistently quadruplicated test cases have been consolidated.
* Fixtures have been introduced to control `auto_id`.
* The test suite is now at 100% code coverage.
* `pytest-randomly` has been introduced to randomize the order of test modules and test cases, which helps demonstrate that tests are fully isolated from each other.

All files have been run through black, isort, and pyupgrade.