### PR TITLE
Use tox to run the test suite against all supported Pythons

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [run]
+parallel = True
 branch = True
 source = jsonpath_ng, tests
+
+[report]
+fail_under = 82

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run tests
-      run: make test
+      run: tox run -e py${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,15 @@
 \#(
 .\#*
 
-# Built artifacts
+# Build and test artifacts
 /README.txt
 /dist
 /*.egg-info
 parser.out
-.coverage
 .cache
+.coverage
+.coverage.*
+.tox/
 
 build
 /jsonpath_rw/VERSION

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,8 @@ lint:
 	@flake8 --exclude=tests .
 
 test: clean
-	@echo "$(OK_COLOR)==> Runnings tests ...$(NO_COLOR)"
-	@pytest -s -v --capture sys --cov jsonpath_ng --cov-report term-missing
-
-coverage:
-	@coverage run --source jsonpath_ng -m pytest
-	@coverage report
+	@echo "$(OK_COLOR)==> Running tests ...$(NO_COLOR)"
+	@tox
 
 tag:
 	@echo "$(OK_COLOR)==> Creating tag $(version) ...$(NO_COLOR)"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,2 @@
-pytest
+tox
 flake8
-coverage
-pytest-cov
-pytest-randomly

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,48 @@
+[tox]
+min_version = 4.3.5
+
+envlist =
+    coverage-erase
+    py{3.12, 3.11, 3.10, 3.9, 3.8, 3.7}
+    coverage-report
+
+skip_missing_interpreters = True
+isolated_build = True
+
+
+[testenv]
+package = wheel
+wheel_build_env = build_wheel
+
+depends =
+    py{3.12, 3.11, 3.10, 3.9, 3.8, 3.7}: coverage-erase
+deps =
+    coverage[toml]
+    pytest
+    pytest-randomly
+commands =
+    coverage run -m pytest
+
+
+[testenv:coverage-erase]
+no_package = true
+skip_install = true
+deps =
+    coverage[toml]
+commands =
+    coverage erase
+
+
+[testenv:coverage-report]
+depends =
+    py{3.12, 3.11, 3.10, 3.9, 3.8, 3.7}
+no_package = true
+skip_install = true
+deps =
+    coverage[toml]
+commands_pre =
+    - coverage combine
+commands =
+    coverage report
+command_post =
+    coverage html --fail-under=0


### PR DESCRIPTION
This PR introduces the following changes:

* tox is used to run the test suite against all supported Pythons
* A comprehensive code coverage percentage, 82%, is now enforced to prevent slippage

After this work merges, I'll review the situation with the documentation, which has been [failing to build on ReadTheDocs](https://readthedocs.org/projects/jsonpath-ng/builds/) for a long time. Documentation building and linting will be added to the test suite as additional tox test environments.