### PR TITLE
Fix a GitHub workflow schema issue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: "master"
+    branches:
+      - "master"
   pull_request:
-    branches: "master"
+    branches:
+      - "master"
   schedule:
     - cron: '39 16 * * 5'
 


### PR DESCRIPTION
This PR addresses a schema issue in `codeql.yml`: `branches` must be an array of strings.