### PR TITLE
Add logical negation of relative query existence

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -96,6 +96,9 @@ class Expression(JSONPath):
     def find(self, datum):
         datum = self.target.find(DatumInContext.wrap(datum))
 
+        if self.op == "!":
+            # Negated relative query existence test
+            return not datum
         if not datum:
             return []
         if self.op is None:

--- a/jsonpath_ng/ext/parser.py
+++ b/jsonpath_ng/ext/parser.py
@@ -23,7 +23,7 @@ from . import string as _string
 
 class ExtendedJsonPathLexer(lexer.JsonPathLexer):
     """Custom LALR-lexer for JsonPath"""
-    literals = lexer.JsonPathLexer.literals + ['?', '@', '+', '*', '/', '-']
+    literals = lexer.JsonPathLexer.literals + ['?', '@', '+', '*', '/', '-', '!']
     tokens = (['BOOL'] +
               parser.JsonPathLexer.tokens +
               ['FILTER_OP', 'SORT_DIRECTION', 'FLOAT'])
@@ -119,6 +119,10 @@ class ExtentedJsonPathParser(parser.JsonPathParser):
         else:
             __, left, op, right = p
         p[0] = _filter.Expression(left, op, right)
+
+    def p_expression_not(self, p):
+        "expression : '!' jsonpath"
+        p[0] = _filter.Expression(p[2], p[1], None)
 
     def p_expressions_expression(self, p):
         "expressions : expression"

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -111,6 +111,12 @@ test_cases = (
         id="filter_eq3",
     ),
     pytest.param(
+        'objects[?cow!="moo"]',
+        {"objects": [{"cow": "moo"}, {"cow": "neigh"}]},
+        [{"cow": "neigh"}],
+        id="filter_ne",
+    ),
+    pytest.param(
         "objects[?cow>5]",
         {"objects": [{"cow": 8}, {"cow": 7}, {"cow": 5}, {"cow": "neigh"}]},
         [{"cow": 8}, {"cow": 7}],
@@ -447,6 +453,46 @@ test_cases = (
         },
         ["green"],
         id="boolean-filter-string-true-string-literal",
+    ),
+    pytest.param(
+        '$[?!@..["type"]]',
+        [
+            {
+                "name": "foo",
+                "data": [{"value": "bar"}]
+            },
+            {
+                "name": "foo",
+                "data": [{"value": "bar", "type": "foo"}]
+            }
+        ],
+        [
+            {
+                "name": "foo",
+                "data": [{"value": "bar"}]
+            }
+        ],
+        id="negated_relative_query_existence"
+    ),
+    pytest.param(
+        '$[?!data[*].type]',
+        [
+            {
+                "name": "foo",
+                "data": [{"value": "bar"}]
+            },
+            {
+                "name": "foo",
+                "data": [{"value": "bar", "type": "foo"}]
+            }
+        ],
+        [
+            {
+                "name": "foo",
+                "data": [{"value": "bar"}]
+            }
+        ],
+        id="negated_relative_query_existence_implicit_this"
     ),
 )
 


### PR DESCRIPTION
This pull request adds support for negating a relative query existence test inside a filter expression using the new _not operator_ (`!`). This is a potential solution for #167.

Sticking with example data from #167, this example selects values from `data` that don't contain a `type` property.

```python
from jsonpath_ng.ext import parse

data = [
    {"name": "foo", "data": [{"value": "bar"}]},
    {"name": "foo", "data": [{"value": "bar", "type": "foo"}]},
]
 
query = parse("$[?!@..['type']]")  # or "$[?!data[*].type]"
matches = query.find(data)

print([m.value for m in matches])
# [{'name': 'foo', 'data': [{'value': 'bar'}]}]
```

I've resisted the urge to implement logical negation for other filter expression types, or refactor `ext.filter.Expression`, for now.
