### PR TITLE
Support comma separated indices in path

### DIFF
--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -116,7 +116,7 @@ class JsonPathParser:
 
     def p_jsonpath_idx(self, p):
         "jsonpath : '[' idx ']'"
-        p[0] = p[2]
+        p[0] = Index(*p[2])
 
     def p_jsonpath_slice(self, p):
         "jsonpath : '[' slice ']'"
@@ -132,7 +132,7 @@ class JsonPathParser:
 
     def p_jsonpath_child_idxbrackets(self, p):
         "jsonpath : jsonpath '[' idx ']'"
-        p[0] = Child(p[1], p[3])
+        p[0] = Child(p[1], Index(*p[3]))
 
     def p_jsonpath_child_slicebrackets(self, p):
         "jsonpath : jsonpath '[' slice ']'"
@@ -161,7 +161,11 @@ class JsonPathParser:
 
     def p_idx(self, p):
         "idx : NUMBER"
-        p[0] = Index(p[1])
+        p[0] = [p[1]]
+
+    def p_idx_comma(self, p):
+        "idx : idx ',' idx "
+        p[0] = p[1] + p[3]
 
     def p_slice_any(self, p):
         "slice : '*'"

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -72,6 +72,8 @@ update_test_cases = (
     # -------
     #
     ("[0]", ["foo", "bar", "baz"], "test", ["test", "bar", "baz"]),
+    ("[0, 1]", ["foo", "bar", "baz"], "test", ["test", "test", "baz"]),
+    ("[0, 1]", ["foo", "bar", "baz"], ["test", "test 1"], ["test", "test 1", "baz"]),
     #
     # Slices
     # ------
@@ -156,7 +158,8 @@ update_test_cases = (
 @parsers
 def test_update(parse, expression, data, update_value, expected_value):
     data_copy = copy.deepcopy(data)
-    result = parse(expression).update(data_copy, update_value)
+    update_value_copy = copy.deepcopy(update_value)
+    result = parse(expression).update(data_copy, update_value_copy)
     assert result == expected_value
 
 


### PR DESCRIPTION
Apply changes to allow comma separated indices. e.g some_field[0, 1, 2].
Originally proposed by https://github.com/elrandira in https://github.com/h2non/jsonpath-ng/pull/102
