### PR TITLE
Added a `path` extension that exposes datum's path from the jsonpath itself

### DIFF
--- a/jsonpath_ng/ext/iterable.py
+++ b/jsonpath_ng/ext/iterable.py
@@ -116,3 +116,29 @@ class Keys(JSONPath):
 
     def __repr__(self):
         return 'Keys()'
+
+class Path(JSONPath):
+    """The JSONPath referring to the path of the current object.
+    Concrete syntax is 'path`'.
+    """
+
+    def find(self, datum):
+        datum = DatumInContext.wrap(datum)
+        try:
+            value = str(datum.path)
+        except Exception as e:
+            return []
+        else:
+            return [DatumInContext(value,
+            return [DatumInContext(value,
+                                   context=datum,
+                                   path=Path())]
+
+    def __eq__(self, other):
+        return isinstance(other, Path)
+
+    def __str__(self):
+        return '`path`'
+
+    def __repr__(self):
+        return 'Path()'

--- a/jsonpath_ng/ext/iterable.py
+++ b/jsonpath_ng/ext/iterable.py
@@ -130,7 +130,6 @@ class Path(JSONPath):
             return []
         else:
             return [DatumInContext(value,
-            return [DatumInContext(value,
                                    context=datum,
                                    path=Path())]
 

--- a/jsonpath_ng/ext/parser.py
+++ b/jsonpath_ng/ext/parser.py
@@ -96,6 +96,8 @@ class ExtentedJsonPathParser(parser.JsonPathParser):
             p[0] = _iterable.Len()
         elif p[1] == 'keys':
             p[0] = _iterable.Keys()
+        elif p[1] == 'path':
+            p[0] = _iterable.Path()
         elif p[1] == 'sorted':
             p[0] = _iterable.SortedThis()
         elif p[1].startswith("split("):

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -69,6 +69,12 @@ test_cases = (
         id="keys_dict",
     ),
     pytest.param(
+        "objects.cow.`path`",
+        {"objects": {"cow": "moo", "cat": "neigh"}},
+        "cow",
+        id="path_dict",
+    ),
+    pytest.param(
         "objects[?cow]",
         {"objects": [{"cow": "moo"}, {"cat": "neigh"}]},
         [{"cow": "moo"}],


### PR DESCRIPTION
Obviously this extension does not have much meaning for a developer who uses jsonpath in his python code and can call simply 'datum.path'.

However it opens possibilities for new use cases where a python-written application implements a service that exposes jsonpaths to the user.

As a particular example, consider XPath expressions (with their name() function) in XSLT template.
Similarly, someone could write a templating system that uses jsonpath. 
```
<template match="$">
    <for-each select="*">Object <value-of select="@.`path`"/> has value <value-of select="@"/></for-each>
<template>
```