### PR TITLE
Fix bool filter type to handle None values

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -104,14 +104,9 @@ class Expression(JSONPath):
         found = []
         for data in datum:
             value = data.value
-            if isinstance(self.value, int):
+            if type(self.value) is int:
                 try:
                     value = int(value)
-                except ValueError:
-                    continue
-            elif isinstance(self.value, bool):
-                try:
-                    value = bool(value)
                 except ValueError:
                     continue
 

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -484,6 +484,19 @@ test_cases = (
         ["green"],
         id="boolean-filter-string-true-string-literal",
     ),
+    pytest.param(
+        "foo[?flag = true].color",
+        {
+            "foo": [
+                {"color": "blue", "flag": True},
+                {"color": "green", "flag": 2},
+                {"color": "red", "flag": "hi"},
+                {"color": "gray", "flag": None},
+            ]
+        },
+        ["blue"],
+        id="boolean-filter-with-null",
+    ),
 )
 
 


### PR DESCRIPTION
This PR fixes the issue that `find()` is not able to handle None values as written in the issue https://github.com/h2non/jsonpath-ng/issues/153