### PR TITLE
Introduce roundtrip testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Typing for IDE autocomplete
 - Support for EMOJI and CJK Unicode
 - Support for `DatumInContext` in-place updating
+- Support equality checking of `Operation` instances
+- Support string serialization of `Union` and `Intersect` instances
 
 ## Changed
 - Rename `ExtentedJsonPathParser`
@@ -13,7 +15,19 @@
 - Fix `False` and `None` values
 - Fix single constant case
 - Update field filter to resolve wildcard path issue
-- Vendor copy of ply and remove pickly support from the vendored copy to resolve [CVE-2025-56005](https://nvd.nist.gov/vuln/detail/CVE-2025-56005) 
+- Vendor copy of ply and remove pickle support from the vendored copy to resolve [CVE-2025-56005](https://nvd.nist.gov/vuln/detail/CVE-2025-56005)
+- Fix string serialization throughout the library to enforce roundtrip parsing consistency.
+  - Fields are more conservatively enclosed in quotion marks
+    This fixes serialization and re-parsing of `"00"`, `'%'`, `'0@'` and `"&'"`.
+  - `Operation` instances can now be serialized.
+    This fixes serialization of `0-@` and `A -A`.
+  - `SortedThis` instances can now be serialized and re-parsed.
+    This fixes serialization of `0[/0]`.
+  - `Child` precedence is now preserved using parentheses during serialization.
+    This ensures that serialized strings like `a..b[c]` serialize and re-parse identically.
+- Fix parsing and string serialization of numeric-only identifiers.
+  This fixes parsing of `10`, which was parsed as two separate fields.
+- Fix equality checks for `SortedThis` instances.
 
 ## Removed
 - Python 3.8 and 3.9 no longer supported

--- a/jsonpath_ng/ext/arithmetic.py
+++ b/jsonpath_ng/ext/arithmetic.py
@@ -26,6 +26,7 @@ OPERATOR_MAP = {
 class Operation(JSONPath):
     def __init__(self, left, op, right):
         self.left = left
+        self.op_symbol = op
         self.op = OPERATOR_MAP[op]
         self.right = right
 
@@ -65,8 +66,17 @@ class Operation(JSONPath):
         return [DatumInContext.wrap(r) for r in result]
 
     def __repr__(self):
-        return '%s(%r%s%r)' % (self.__class__.__name__, self.left, self.op,
+        return '%s(%r%s%r)' % (self.__class__.__name__, self.left, self.op_symbol,
                                self.right)
 
     def __str__(self):
-        return '%s%s%s' % (self.left, self.op, self.right)
+        return '%s %s %s' % (self.left, self.op_symbol, self.right)
+
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Operation)
+            and self.left == other.left
+            and self.op_symbol == other.op_symbol
+            and self.right == other.right
+        )

--- a/jsonpath_ng/ext/iterable.py
+++ b/jsonpath_ng/ext/iterable.py
@@ -56,13 +56,20 @@ class SortedThis(This):
         return datum
 
     def __eq__(self, other):
-        return isinstance(other, Len)
+        return (
+            isinstance(other, SortedThis)
+            and self.expressions == other.expressions
+        )
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self.expressions)
 
     def __str__(self):
-        return '[?%s]' % self.expressions
+        expressions: list[str] = []
+        for (field, reverse) in self.expressions:
+            prefix = "\\" if reverse else "/"
+            expressions.append(f"{prefix}{field}")
+        return f"[{', '.join(expressions)}]"
 
 
 class Len(JSONPath):

--- a/jsonpath_ng/parser.py
+++ b/jsonpath_ng/parser.py
@@ -154,7 +154,7 @@ class JsonPathParser:
         if p[1] == '*':
             p[0] = ['*']
         elif isinstance(p[1], int):
-            p[0] = str(p[1])
+            p[0] = [str(p[1])]
         else:
             p[0] = p[1]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 tox
 flake8
 pytest
+hypothesis

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,10 +10,10 @@ def assert_value_equality(results, expected_values):
 
     left_values = [result.value for result in results]
     if isinstance(expected_values, list):
-        assert left_values == expected_values
+        assert left_values == expected_values, f"{left_values!r} != {expected_values!r}"
     elif isinstance(expected_values, set):
         assert len(left_values) == len(expected_values)
-        assert set(left_values) == expected_values
+        assert set(left_values) == expected_values, f"{left_values!r} != {expected_values!r}"
     else:
         assert results[0].value == expected_values
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,0 +1,52 @@
+from hypothesis import example, given, settings, strategies as st, assume
+
+import jsonpath_ng
+import jsonpath_ng.exceptions
+import jsonpath_ng.ext
+
+characters = st.characters(min_codepoint=0x20, max_codepoint=0x7e)  # space -> tilde
+ascii_text = st.text(characters)
+
+@given(ascii_text)
+@example("10")
+@example("0&0")
+@example("';'")
+@example('"0@"')
+@example('"00"')
+@example(r'"\'"')
+@example("0..0[0]")
+@example("(0..0)[0]")
+@example("0..(0[0])")
+@example("0..0.[0]")
+@settings(max_examples=20)
+def test_roundtrip_basic(string: str):
+    try:
+        parsed_original = jsonpath_ng.parse(string)
+    except jsonpath_ng.exceptions.JSONPathError:
+        assume(False)
+        return
+
+    reconstituted = str(parsed_original)
+    parsed_reconstituted = jsonpath_ng.parse(reconstituted)
+    assert parsed_original == parsed_reconstituted
+
+
+@given(ascii_text)
+@example("0-@")
+@example("0|0")
+@example("'%'")
+@example("''")
+@example("A -A")
+@example("A -@")
+@example("0[/0]")
+@settings(max_examples=20)
+def test_roundtrip_extended(string: str):
+    try:
+        parsed_original = jsonpath_ng.ext.parse(string)
+    except jsonpath_ng.exceptions.JSONPathError:
+        assume(False)
+        return
+
+    reconstituted = str(parsed_original)
+    parsed_reconstituted = jsonpath_ng.ext.parse(reconstituted)
+    assert parsed_original == parsed_reconstituted

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ depends =
     py{3.14, 3.13, 3.12, 3.11, 3.10}: coverage-erase
 deps =
     coverage[toml]
+    hypothesis
     pytest
     pytest-randomly
 commands =


### PR DESCRIPTION
While working on #206, I kept encountering bugs and missing features in the existing implementation's `JsonPath` string serialization and equality methods that hampered comparison and roundtrip testing. I'm therefore submitting this PR to fix bugs in the existing implementation.

This PR introduces the following changes:

* Add hypothesis as a testing tool
* Add roundtrip testing: given an arbitrary string that can be parsed, it should be possible to parse the string, serialize the JsonPath instance back to a string, and re-parse that string back to the same JsonPath instance.

I had hypothesis generate ~10,000,000 examples cumulatively, which identified a number of issues in the current implementation:

----

## Added
- Support equality checking of `Operation` instances
- Support string serialization of `Union` and `Intersect` instances

## Fixed
- Fix string serialization throughout the library to enforce roundtrip parsing consistency.
  - Fields are more conservatively enclosed in quotion marks.
    This fixes serialization and re-parsing of `"00"`, `'%'`, `'0@'` and `"&'"`.
  - `Operation` instances can now be serialized.
    This fixes serialization of `0-@` and `A -A`.
  - `SortedThis` instances can now be serialized and re-parsed.
    This fixes serialization of `0[/0]`.
  - `Child` precedence is now preserved using parentheses during serialization.
    This ensures that serialized strings like `a..b[c]` serialize and re-parse identically.
- Fix parsing and string serialization of numeric-only identifiers.
  This fixes parsing of `10`, which was parsed as two separate fields.
- Fix equality checks for `SortedThis` instances.
