### PR TITLE
Fix broken `Slice` serialization behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix broken `Slice` serialization behavior.
+
+  Previously, a slice like `[0:]` would serialize to `[]`,
+  and a slice like `[::2]` would serialize to `[:2]`.
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -847,12 +847,20 @@ class Slice(JSONPath):
         return data
 
     def __str__(self):
-        if self.start is None and self.end is None and self.step is None:
-            return '[*]'
-        else:
-            return '[%s%s%s]' % (self.start or '',
-                                   ':%d'%self.end if self.end else '',
-                                   ':%d'%self.step if self.step else '')
+        elements = []
+
+        for i, element in enumerate((self.start, self.end, self.step)):
+            if element is None:
+                continue
+            # Ensure that `elements` contains `i` elements, then append `element`.
+            elements.extend([""] * (i - len(elements)))
+            elements.append(str(element))
+
+        # If only `start` is present, add a blank element to ensure a trailing ':'.
+        if len(elements) == 1:
+            elements.append("")
+
+        return f'[{":".join(elements) or "*"}]'
 
     def __repr__(self):
         return '%s(start=%r,end=%r,step=%r)' % (self.__class__.__name__, self.start, self.end, self.step)

--- a/tests/jsonpath/test_slice.py
+++ b/tests/jsonpath/test_slice.py
@@ -1,0 +1,44 @@
+import pytest
+
+import jsonpath_ng
+import jsonpath_ng.ext
+
+
+parsers = pytest.mark.parametrize(
+    "parse",
+    (jsonpath_ng.parse, jsonpath_ng.ext.parse),
+    ids=lambda function: function.__module__,
+)
+
+
+@pytest.mark.parametrize(
+    "data, expected_start, expected_end, expected_step",
+    (
+        # Special case
+        pytest.param("[*]", None, None, None, id="wildcard"),
+        # Individual elements
+        pytest.param("[0:]", 0, None, None, id="start-false-y"),
+        pytest.param("[1:]", 1, None, None, id="start-1"),
+        pytest.param("[:0]", None, 0, None, id="end-false-y"),
+        pytest.param("[:1]", None, 1, None, id="end-1"),
+        pytest.param("[::0]", None, None, 0, id="step-nonsense"),
+        pytest.param("[::1]", None, None, 1, id="step-default"),
+        pytest.param("[::2]", None, None, 2, id="step-2"),
+        # Paired elements
+        pytest.param("[1:2]", 1, 2, None, id="start-and-end"),
+        pytest.param("[:1:2]", None, 1, 2, id="end-and-step"),
+        pytest.param("[1::2]", 1, None, 2, id="start-and-step"),
+        # All elements
+        pytest.param("[1:2:3]", 1, 2, 3, id="all-elements"),
+    )
+)
+@parsers
+def test_slice(parse, data, expected_start, expected_end, expected_step):
+    instance = parse(data)
+
+    assert isinstance(instance, jsonpath_ng.Slice)
+    assert instance.start == expected_start
+    assert instance.end == expected_end
+    assert instance.step == expected_step
+
+    assert str(instance) == data


### PR DESCRIPTION
Examples of broken `Slice` serialization behavior:

```python
from jsonpath_ng import parse

print(str(parse("[0:]")))  # '[]' -- cannot be re-parsed

print(str(parse("[::2]")))  # '[:2]' -- `step` is now `end`
```

These issues were found while investigating an issue report.

In anticipation of stronger testing, this introduces a new test subdirectory, `tests/jsonpath/`.
