### PR TITLE
Stop wrapping `Child` instances in parentheses

### DIFF
--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -320,8 +320,7 @@ class Child(JSONPath):
         if isinstance(self.right, SortedThis):
             return f"{self.left}{self.right}"
 
-        # Parentheses are required to ensure precedence.
-        return f"({self.left}.{self.right})"
+        return f"{self.left}.{self.right}"
 
     def __repr__(self):
         return '%s(%r, %r)' % (self.__class__.__name__, self.left, self.right)

--- a/tests/jsonpath/test_child.py
+++ b/tests/jsonpath/test_child.py
@@ -1,0 +1,41 @@
+import pytest
+
+import jsonpath_ng.ext
+
+
+parsers = pytest.mark.parametrize(
+    "parse",
+    (jsonpath_ng.parse, jsonpath_ng.ext.parse),
+    ids=lambda function: function.__module__,
+)
+
+
+@pytest.mark.parametrize(
+    "data, expected_serialization",
+    (
+        ("a.b", "a.b"),
+        ("a[b]", "a.b"),
+        ("a.b.c", "a.b.c"),
+        ("'a.b'.c", "'a.b'.c"),
+        ("a.'b.c'", "a.'b.c'"),
+        ("a..b[c]", "(a..b).c"),
+        ("(a..b)[c]", "(a..b).c"),
+        ("(a..b).c", "(a..b).c"),
+    ),
+)
+@parsers
+def test_serialization(parse, data, expected_serialization):
+    """Test serialization of Child instances.
+
+    Regardless of what the test inputs claim,
+    the expected serialization must still parse to the same JSONPath
+    that the original data parsed to.
+    """
+
+    parsed = parse(data)
+    reserialized = str(parsed)
+
+    assert reserialized == expected_serialization
+
+    # Now that the test has succeeded, do an additional sanity check.
+    assert parsed == parse(reserialized)

--- a/tests/jsonpath/test_descendants.py
+++ b/tests/jsonpath/test_descendants.py
@@ -1,0 +1,38 @@
+import pytest
+
+import jsonpath_ng.ext
+
+
+parsers = pytest.mark.parametrize(
+    "parse",
+    (jsonpath_ng.parse, jsonpath_ng.ext.parse),
+    ids=lambda function: function.__module__,
+)
+
+
+@pytest.mark.parametrize(
+    "data, expected_serialization",
+    (
+        ("a..b", "(a..b)"),  # Not ideal
+        # This is not an ideal serialization,
+        # nor is it consistent with the precedence rules of 'a..b[c]', below.
+        ("a..b.c", "(a..b.c)"),
+        ("a..b[c]", "(a..b).c"),
+    ),
+)
+@parsers
+def test_serialization(parse, data, expected_serialization):
+    """Test serialization of Descendant instances.
+
+    Regardless of what the test inputs claim,
+    the expected serialization must still parse to the same JSONPath
+    that the original data parsed to.
+    """
+
+    parsed = parse(data)
+    reserialized = str(parsed)
+
+    assert reserialized == expected_serialization
+
+    # Now that the test has succeeded, do an additional sanity check.
+    assert parsed == parse(reserialized)

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -234,7 +234,7 @@ find_test_cases = (
     #
     ("`this`", {"foo": "baz"}, [{"foo": "baz"}], ["`this`"]),
     ("foo.`this`", {"foo": "baz"}, ["baz"], ["foo"]),
-    ("foo.`this`.baz", {"foo": {"baz": 3}}, [3], ["(foo.baz)"]),
+    ("foo.`this`.baz", {"foo": {"baz": 3}}, [3], ["foo.baz"]),
     #
     # Indexes
     # -------
@@ -268,14 +268,14 @@ find_test_cases = (
     ("[*]", None, [], []),
     ("[0:]", 1, [1], ["[0]"]),
     ("[*]", {"foo": 1}, [{"foo": 1}], ["[0]"]),
-    ("[*].foo", {"foo": 1}, [1], ["([0].foo)"]),
+    ("[*].foo", {"foo": 1}, [1], ["[0].foo"]),
     #
     # Children
     # --------
     #
-    ("foo.baz", {"foo": {"baz": 3}}, [3], ["(foo.baz)"]),
-    ("foo.baz", {"foo": {"baz": [3]}}, [[3]], ["(foo.baz)"]),
-    ("foo.baz.qux", {"foo": {"baz": {"qux": 5}}}, [5], ["((foo.baz).qux)"]),
+    ("foo.baz", {"foo": {"baz": 3}}, [3], ["foo.baz"]),
+    ("foo.baz", {"foo": {"baz": [3]}}, [[3]], ["foo.baz"]),
+    ("foo.baz.qux", {"foo": {"baz": {"qux": 5}}}, [5], ["foo.baz.qux"]),
     #
     # Descendants
     # -----------
@@ -284,13 +284,13 @@ find_test_cases = (
         "foo..baz",
         {"foo": {"baz": 1, "bing": {"baz": 2}}},
         [1, 2],
-        ["(foo.baz)", "((foo.bing).baz)"],
+        ["foo.baz", "foo.bing.baz"],
     ),
     (
         "foo..baz",
         {"foo": [{"baz": 1}, {"baz": 2}]},
         [1, 2],
-        ["((foo.[0]).baz)", "((foo.[1]).baz)"],
+        ["foo.[0].baz", "foo.[1].baz"],
     ),
     #
     # Parents
@@ -301,24 +301,24 @@ find_test_cases = (
         "foo.`parent`.foo.baz.`parent`.baz.qux",
         {"foo": {"baz": {"qux": 5}}},
         [5],
-        ["((foo.baz).qux)"],
+        ["foo.baz.qux"],
     ),
     #
     # Hyphens
     # -------
     #
-    ("foo.bar-baz", {"foo": {"bar-baz": 3}}, [3], ["(foo.bar-baz)"]),
+    ("foo.bar-baz", {"foo": {"bar-baz": 3}}, [3], ["foo.bar-baz"]),
     (
         "foo.[bar-baz,blah-blah]",
         {"foo": {"bar-baz": 3, "blah-blah": 5}},
         [3, 5],
-        ["(foo.bar-baz)", "(foo.blah-blah)"],
+        ["foo.bar-baz", "foo.blah-blah"],
     ),
     #
     # Literals
     # --------
     #
-    ("A.'a.c'", {"A": {"a.c": "d"}}, ["d"], ["(A.'a.c')"]),
+    ("A.'a.c'", {"A": {"a.c": "d"}}, ["d"], ["A.'a.c'"]),
     #
     # Numeric keys
     # --------
@@ -366,7 +366,7 @@ find_test_cases_with_auto_id = (
     #
     ("id", {"foo": "baz"}, ["`this`"]),
     ("foo.`this`.id", {"foo": "baz"}, ["foo"]),
-    ("foo.`this`.baz.id", {"foo": {"baz": 3}}, ["(foo.baz)"]),
+    ("foo.`this`.baz.id", {"foo": {"baz": 3}}, ["foo.baz"]),
     #
     # Indexes
     # -------
@@ -383,11 +383,11 @@ find_test_cases_with_auto_id = (
     # Children
     # --------
     #
-    ("foo.baz.id", {"foo": {"baz": 3}}, ["(foo.baz)"]),
-    ("foo.baz.id", {"foo": {"baz": [3]}}, ["(foo.baz)"]),
-    ("foo.baz.id", {"foo": {"id": "bizzle", "baz": 3}}, ["(bizzle.baz)"]),
-    ("foo.baz.id", {"foo": {"baz": {"id": "hi"}}}, ["(foo.hi)"]),
-    ("foo.baz.bizzle.id", {"foo": {"baz": {"bizzle": 5}}}, ["((foo.baz).bizzle)"]),
+    ("foo.baz.id", {"foo": {"baz": 3}}, ["foo.baz"]),
+    ("foo.baz.id", {"foo": {"baz": [3]}}, ["foo.baz"]),
+    ("foo.baz.id", {"foo": {"id": "bizzle", "baz": 3}}, ["bizzle.baz"]),
+    ("foo.baz.id", {"foo": {"baz": {"id": "hi"}}}, ["foo.hi"]),
+    ("foo.baz.bizzle.id", {"foo": {"baz": {"bizzle": 5}}}, ["foo.baz.bizzle"]),
     #
     # Descendants
     # -----------
@@ -395,7 +395,7 @@ find_test_cases_with_auto_id = (
     (
         "foo..baz.id",
         {"foo": {"baz": 1, "bing": {"baz": 2}}},
-        ["(foo.baz)", "((foo.bing).baz)"],
+        ["foo.baz", "foo.bing.baz"],
     ),
 )
 
@@ -416,9 +416,9 @@ def test_find_full_paths_auto_id(auto_id_field, parse):
 @pytest.mark.parametrize(
     "string, target",
     (
-        ("m.[1].id", ["(('1'.m).a2id)"]),
-        ("m.[1].$.b.id", ["('1'.bid)"]),
-        ("m.[0].id", ["(('1'.m).[0])"]),
+        ("m.[1].id", ["'1'.m.a2id"]),
+        ("m.[1].$.b.id", ["'1'.bid"]),
+        ("m.[0].id", ["'1'.m.[0]"]),
     ),
 )
 @parsers


### PR DESCRIPTION
Fixes #215