### PR TITLE
fix: update Index.__hash__ to reference self.indices instead of self.index

### DIFF
--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -779,7 +779,7 @@ class Index(JSONPath):
             value += [{} for __ in range(pad)]
 
     def __hash__(self):
-        return hash(self.index)
+        return hash(self.indices)
 
 
 class Slice(JSONPath):

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -3,7 +3,7 @@ import copy
 import pytest
 from typing import Callable
 from jsonpath_ng.ext.parser import parse as ext_parse
-from jsonpath_ng.jsonpath import DatumInContext, Fields, Root, This
+from jsonpath_ng.jsonpath import DatumInContext, Fields, Index, Root, This
 from jsonpath_ng.lexer import JsonPathLexerError
 from jsonpath_ng.parser import parse as base_parse
 from jsonpath_ng import JSONPath
@@ -435,3 +435,15 @@ def test_nested_index_auto_id(auto_id_field, parse, string, target):
 def test_invalid_hyphenation_in_key():
     with pytest.raises(JsonPathLexerError):
         base_parse("foo.-baz")
+
+
+def test_index_hashable():
+    idx = Index(0)
+    assert hash(idx) == hash((0,))
+    assert {idx: "value"}[idx] == "value"
+
+
+def test_index_multi_indices_hashable():
+    idx = Index(0, 1, 2)
+    assert hash(idx) == hash((0, 1, 2))
+    assert {idx: "value"}[idx] == "value"


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'Index' object has no attribute 'index'` when `Index` objects are used in hash-based collections (e.g., as dictionary keys).

The `Index` class was refactored from `__init__(self, index)` with `self.index` to `__init__(self, *indices)` with `self.indices`, but `__hash__` was not updated and still references the removed `self.index` attribute.

**Fix:** Change `return hash(self.index)` to `return hash(self.indices)` in `Index.__hash__`.

Fixes #224

## Reproduction

```python
from jsonpath_ng import parse as jsonpath

schema = {"items": [{"name": "first"}, {"name": "second"}]}
results = {}
for match in jsonpath("$.items[*].name").find(schema):
    results[match.full_path] = match.value
print(results)
```

Before fix: `AttributeError: 'Index' object has no attribute 'index'`
After fix: prints matched paths and values as expected.