### PR TITLE
Fix str() of Index with multiple indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `str()` of an `Index` with multiple comma-separated indices (e.g. `[0,1]`) no longer raises `TypeError`
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -767,7 +767,7 @@ class Index(JSONPath):
         return isinstance(other, Index) and sorted(self.indices) == sorted(other.indices)
 
     def __str__(self):
-        return '[%i]' % self.indices
+        return '[%s]' % ','.join(str(index) for index in self.indices)
 
     def __repr__(self):
         return '%s(indices=%r)' % (self.__class__.__name__, self.indices)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -18,6 +18,7 @@ ascii_text = st.text(characters)
 @example("(0..0)[0]")
 @example("0..(0[0])")
 @example("0..0.[0]")
+@example("0[0,1]")  # multi-index: str(Index(0, 1)) used to raise TypeError
 @settings(max_examples=20)
 def test_roundtrip_basic(string: str):
     try:


### PR DESCRIPTION
`str()` of an `Index` with more than one index raises `TypeError`:

```python
>>> from jsonpath_ng import parse
>>> str(parse('foo[0,1]'))
TypeError: not all arguments converted during string formatting
>>> from jsonpath_ng.jsonpath import Index
>>> str(Index(0, 1))
TypeError: not all arguments converted during string formatting
```

`Index.__init__(self, *indices)` stores `self.indices` as a tuple, but `__str__` still uses the single-value format:

```python
def __str__(self):
    return '[%i]' % self.indices
```

`'[%i]' % (0,)` happens to work for one index, but `'[%i]' % (0, 1)` raises. Comma-separated indices have been parseable since 1.8.0 ("Support comma-separated indices"), so `Index` could hold multiple indices but couldn't be serialized — which also breaks `str(parse(...))` round-tripping for such expressions.

Fix: format each index and join with commas (`'[%s]' % ','.join(...)`). Single-index output is unchanged (`[0]`); multi-index now serializes as `[0,1]`.

Added `@example("0[0,1]")` to `test_roundtrip_basic` (it raised before the fix) and a CHANGELOG entry under Unreleased.
