### PR TITLE
Fix extended parser fields starting with true or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix extended parser handling of field names that start with `true` or `false`.
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/ext/parser.py
+++ b/jsonpath_ng/ext/parser.py
@@ -31,7 +31,7 @@ class ExtendedJsonPathLexer(lexer.JsonPathLexer):
     t_FILTER_OP = r'=~|==?|<=|>=|!=|<|>'
 
     def t_BOOL(self, t):
-        r'true|false'
+        r'true(?![a-zA-Z0-9_@\-])|false(?![a-zA-Z0-9_@\-])'
         t.value = True if t.value == 'true' else False
         return t
 

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -485,6 +485,18 @@ test_cases = (
         id="boolean-filter-string-true-string-literal",
     ),
     pytest.param(
+        "false_positives",
+        {"problems_detected": 4, "false_positives": 2},
+        [2],
+        id="field-starting-with-false",
+    ),
+    pytest.param(
+        "trueName",
+        {"trueName": "value"},
+        ["value"],
+        id="field-starting-with-true",
+    ),
+    pytest.param(
         "foo[?flag = true].color",
         {
             "foo": [


### PR DESCRIPTION
Fixes #177.\n\nThe extended lexer was tokenizing any identifier beginning with `true` or `false` as a `BOOL` prefix, so paths like `trueName` and `false_positives` failed before the normal field parser could see them.\n\nThis keeps `true` / `false` as boolean literals only when they are not followed by an identifier character, and adds regression coverage for both prefixes.\n\nTests:\n- `uv run --with pytest --with hypothesis --with pytest-randomly pytest -q`