### PR TITLE
Add support for PEP 517.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 filterwarnings = [
     # Escalate warnings to errors.


### PR DESCRIPTION
Using `setup.py` directly is deprecated.