### PR TITLE
Match nothing instead of raising KeyError for Index on a dict (fixes #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `Index.find` no longer raises `KeyError` when applied to a dict (e.g. `$.*[0]`
+  where `*` matched a dict value); it now matches nothing, as the docstring
+  promises ([#93](https://github.com/h2non/jsonpath-ng/issues/93))
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -724,6 +724,12 @@ class Index(JSONPath):
                 datum.value = _create_list_key(datum.value)
             self._pad_value(datum.value)
         rv = []
+        if isinstance(datum.value, dict):
+            # Integer indices apply to sequences, not mappings. A dict passes
+            # the len() check below but datum.value[index] is a key lookup that
+            # raises KeyError, so match nothing instead (as the class docstring
+            # promises) -- e.g. ``$.*[0]`` where ``*`` matched a dict value.
+            return rv
         for index in self.indices:
             # invalid indices do not crash, return [] instead
             if datum.value and len(datum.value) > index:

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -243,6 +243,9 @@ find_test_cases = (
     ("[5]", [42], [], []),
     ("[2]", [34, 65, 29, 59], [29], ["[2]"]),
     ("[0]", None, [], []),
+    # Indexing a dict matches nothing rather than raising KeyError (issue #93)
+    ("[0]", {"foo": 1}, [], []),
+    ("$.*[0].b", {"a": [{"b": 1}], "c": {"d": 2}}, [1], ["((a.[0]).b)"]),
     #
     # Slices
     # ------


### PR DESCRIPTION
## Summary

Fixes #93. `Index.find` (the concrete `[n]` syntax) raises an uncaught `KeyError` when it is applied to a dict:

```python
import jsonpath_ng
jsonpath_ng.parse("$.*[0].b").find({"a": [{"b": 1}], "c": {"d": 2}})
# KeyError: 0
```

The wildcard `*` matches every value (including the dict `{"d": 2}`), then `[0]` is applied to each — and indexing the dict raises. Minimal repro: `jsonpath_ng.parse("[0]").find({"foo": 1})`.

This contradicts the class's own docstring — *"If the datum is None or not long enough, it will not crash but will not match anything"* — and is inconsistent with the sibling paths: `Slice` (`[*]`) and `Fields` (`.foo`) both handle a dict datum gracefully. Only `Index` crashes.

## Cause

In `Index._find_base`, the guard

```python
if datum.value and len(datum.value) > index:
    rv += [DatumInContext(datum.value[index], ...)]
```

assumes anything with a `len()` is integer-indexable. A dict satisfies `len(datum.value) > index`, but `datum.value[index]` is then a key lookup that raises `KeyError`.

## Fix

Return early when the datum is a dict — integer indices apply to sequences, not mappings, so (per the docstring) match nothing rather than crashing. Sequence and string indexing are untouched.

```python
rv = []
if isinstance(datum.value, dict):
    return rv
for index in self.indices:
    ...
```

The fix is scoped to the `find` contract; `find_or_create` on an empty dict still converts it to a list first (in the `create` block above), so that path is unaffected.

## Verification

- Added two cases to the `find_test_cases` table: `("[0]", {"foo": 1}, [], [])` and the issue #93 repro `("$.*[0].b", {"a": [{"b": 1}], "c": {"d": 2}}, [1], ["((a.[0]).b)"])`. They fail with `KeyError` before the fix and pass after (confirmed via `git stash`).
- List/tuple/string indexing behavior is preserved.
- Full suite: **355 passed** (was 351).
- Added a `### Fixed` entry to `CHANGELOG.md` under `[Unreleased]`.

This pull request was prepared with the assistance of AI, under my direction and review.
