### PR TITLE
Fix AttributeError when filtering a dict with an extended [?(...)] expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix `AttributeError` when filtering a dict with `.filter()` and an extended `[?(...)]` expression
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -59,7 +59,7 @@ class Filter(JSONPath):
         for datum in reversed(self.find(data)):
             index_obj = datum.path
             if isinstance(data, dict):
-                index_obj.index = list(data)[index_obj.index]
+                index_obj.indices = [list(data)[i] for i in index_obj.indices]
             index_obj.filter(fn, data)
         return data
 

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -512,3 +512,14 @@ def test_invalid_hyphenation_in_key():
     # This discrepancy needs to be resolved.
     with pytest.raises(JsonPathParserError):
         parser.parse("foo.-baz")
+
+
+def test_filter_on_dict():
+    # Filtering a dict must delete the matching key/value pairs, not crash.
+    data = {
+        "alice": {"score": 10},
+        "bob": {"score": -5},
+        "carol": {"score": -1},
+    }
+    parser.parse("$[?(@.score < 0)]").filter(lambda v: True, data)
+    assert data == {"alice": {"score": 10}}


### PR DESCRIPTION
Filtering a `dict` with an extended `[?(...)]` expression crashes instead of removing the matching entries:

```python
from jsonpath_ng.ext import parse
data = {"alice": {"score": 10}, "bob": {"score": -5}, "carol": {"score": -1}}
parse("$[?(@.score < 0)]").filter(lambda v: True, data)
# AttributeError: 'Index' object has no attribute 'index'
# expected: data == {"alice": {"score": 10}}
```

**Root cause** (`jsonpath_ng/ext/filter.py`): `Index` was refactored (1.8.0) from a single `.index` attribute to `.indices` (a tuple, for comma-separated indices), and every `Index` consumer was updated **except** the dict branch of `Filter.filter`, which still reads and writes the removed `.index`:

```python
if isinstance(data, dict):
    index_obj.index = list(data)[index_obj.index]   # 'Index' has no attribute 'index'
```

The `if isinstance(data, dict)` branch shows dict filtering is intended (issue #41, closed as supported), so this is a regression/crash, not a semantics choice.

**Fix** (1 line): map each positional index (from `Filter.find`, which walks the dict as `list(values())`) to its key and store it in `.indices`, which `Index.filter` now iterates:

```python
-                index_obj.index = list(data)[index_obj.index]
+                index_obj.indices = [list(data)[i] for i in index_obj.indices]
```

List filtering is unaffected.

**Verification** (re-runnable from the diff): added `test_filter_on_dict` — it fails on the current tree (`AttributeError`) and passes with the fix; the full suite is `352 passed`. List filtering and selective-predicate filtering re-verified. CHANGELOG entry added.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
