### PR TITLE
fix: update() with in-place callback returning None no longer overwrites field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `update()` with an in-place callback returning `None` no longer overwrites the field with `None` (#163)
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -664,7 +664,9 @@ class Fields(JSONPath):
                     data[field] = {}
                 if type(data) is not bool and field in data:
                     if hasattr(val, '__call__'):
-                        data[field] = val(data[field], data, field)
+                        val_result = val(data[field], data, field)
+                        if val_result is not None:
+                            data[field] = val_result
                     else:
                         data[field] = val
         return data
@@ -743,7 +745,9 @@ class Index(JSONPath):
             self._pad_value(data)
         if hasattr(val, '__call__'):
             for index in self.indices:
-                val.__call__(data[index], data, index)
+                val_result = val.__call__(data[index], data, index)
+                if val_result is not None:
+                    data[index] = val_result
         else:
             for index in self.indices:
                 if len(data) > index:

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -188,6 +188,60 @@ def test_update(parse: Callable[[str], JSONPath], expression: str, data, update_
     assert data_copy2 == expected_value
 
 
+@parsers
+def test_update_with_inplace_callback(parse: Callable[[str], JSONPath]):
+    """Regression test for #163: update() with an in-place callback that
+    returns None should not overwrite the field with None."""
+
+    def lowercase_inplace(orig, data, field):
+        data[field] = data[field].lower()
+        # intentionally returns None
+
+    data = {
+        'Data_cat': {
+            'data_entry': [
+                {'value': 0, 'UPPERCASE': 'UPPERCASE_A'},
+                {'value': 2, 'UPPERCASE': 'UPPERCASE_B'},
+            ]
+        }
+    }
+    parse('$..UPPERCASE').update(data, lowercase_inplace)
+    assert data == {
+        'Data_cat': {
+            'data_entry': [
+                {'value': 0, 'UPPERCASE': 'uppercase_a'},
+                {'value': 2, 'UPPERCASE': 'uppercase_b'},
+            ]
+        }
+    }
+
+
+@parsers
+def test_update_with_returning_callback(parse: Callable[[str], JSONPath]):
+    """Ensure callbacks that return a value still work correctly."""
+
+    def lowercase_return(orig, data, field):
+        return orig.lower()
+
+    data = {
+        'Data_cat': {
+            'data_entry': [
+                {'value': 0, 'UPPERCASE': 'UPPERCASE_A'},
+                {'value': 2, 'UPPERCASE': 'UPPERCASE_B'},
+            ]
+        }
+    }
+    parse('$..UPPERCASE').update(data, lowercase_return)
+    assert data == {
+        'Data_cat': {
+            'data_entry': [
+                {'value': 0, 'UPPERCASE': 'uppercase_a'},
+                {'value': 2, 'UPPERCASE': 'uppercase_b'},
+            ]
+        }
+    }
+
+
 filter_test_cases = (
     # Docs examples
     ("foo[*].baz", {'foo': [{'baz': 1}, {'baz': 2}]}, lambda d: True, {'foo': [{}, {}]}),


### PR DESCRIPTION
Fixes #163

## Problem

Since commit 7987969 (`Fix issue with lambda based updates`), `Fields._update_base` assigns the return value of the callable back to `data[field]`:

`python
data[field] = val(data[field], data, field)
`

This broke callbacks that modify `data[field]` **in-place** and return `None` (the pre-7987969 pattern that issue #163 relies on), because `None` overwrites the value the callback just set.

`Index._update_base` had the opposite inconsistency — it called the callable **without** assigning the return, so return-value callbacks were silently ignored for array indices.

## Root cause

Neither `Fields._update_base` nor `Index._update_base` handled both callback styles (in-place and return-value).

## Fix

Both methods now capture the callable's return value and only assign it if it is **not** `None`. If the callable returns `None` (explicitly or implicitly), the in-place modification is preserved.

### ⚠️ Behavior change: intentionally setting `None` via a returning callback

This fix means a callback like `lambda orig, data, field: None` can no longer be used to deliberately set a field to `None` via its return value. No existing test or documented behavior relies on this pattern, and it is the only reasonable way to restore compatibility with the in-place callback contract that existed before 7987969 and that issue #163 depends on. Callers who need to set `None` can still do so inside the callback body: `data[field] = None`.

For `Index._update_base`, this is a net improvement — return-value callbacks (e.g. `lambda orig, data, idx: orig + 1`) now work for array indices, where previously the return value was silently discarded.

## Reproduction

`python
from jsonpath_ng import parse

def lowercase_inplace(orig, data, field):
    data[field] = data[field].lower()
    # returns None

data = {'Data_cat': {'data_entry': [
    {'value': 0, 'UPPERCASE': 'UPPERCASE_A'},
    {'value': 2, 'UPPERCASE': 'UPPERCASE_B'},
]}}
parse('$..UPPERCASE').update(data, lowercase_inplace)
# Before fix: UPPERCASE fields become None
# After fix:  UPPERCASE fields become lowercase strings
`

## Validation

- 2 new regression tests (in-place and return-value callbacks with `$..field` doubledot notation)
- Full test suite: **355 tests passed**, 0 failures
- The only existing lambda update test (`lambda x, y, z: x + 1`) exercises `Fields` (not `Index`) and continues to pass