### PR TITLE
Fix filter equality against int literal truncating float values (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix extended filter equality against an integer literal truncating float values,
+  so `[?(@.v = 0)]` no longer matches an element with `v = 0.6` ([#227](https://github.com/h2non/jsonpath-ng/issues/227)).
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -104,7 +104,7 @@ class Expression(JSONPath):
         found = []
         for data in datum:
             value = data.value
-            if type(self.value) is int:
+            if type(self.value) is int and isinstance(value, str):
                 try:
                     value = int(value)
                 except ValueError:

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -497,6 +497,12 @@ test_cases = (
         ["blue"],
         id="boolean-filter-with-null",
     ),
+    pytest.param(
+        "foo[?(@.v = 0)].k",
+        {"foo": [{"k": "A", "v": 0.0}, {"k": "B", "v": 0.6}, {"k": "C", "v": 0}]},
+        ["A", "C"],
+        id="issue-227-int-no-float-truncation",
+    ),
 )
 
 


### PR DESCRIPTION
Fixes #227.

### Problem
An extended filter comparing against an integer literal wrongly matched float values. For example `$[?(@.v = 0)]` matched an element with `v = 0.6`:

```python
from jsonpath_ng.ext import parse
data = [{"k": "A", "v": 0.0}, {"k": "B", "v": 0.6}, {"k": "C", "v": 0}]
parse("$[?(@.v = 0)].k").find(data)   # returned ["A", "B", "C"], expected ["A", "C"]
```

### Root cause
In `Expression.find` (`jsonpath_ng/ext/filter.py`), when the RHS literal is an `int`, the LHS value was coerced with `int(value)` before comparison. For a float LHS this truncates (`int(0.6) == 0`), so an equality filter against `0` wrongly matched `0.6`.

### Fix
Restrict the coercion to string LHS values (`isinstance(value, str)`). This preserves the original string->int intent (e.g. matching `"5"` against `5`) while leaving numeric values uncoerced, so float comparisons stay exact. Booleans are unaffected (`type(True) is int` is `False`).

### Tests
- Added a parametrized case `issue-227-int-no-float-truncation`.
- Red/green verified: without the fix the case returns `["A", "B", "C"]` (fails); with the fix it returns `["A", "C"]`.
- Full ext suite and `tests/` pass (352 passed).
- CHANGELOG.md updated under `[Unreleased] / Fixed` per CONTRIBUTING.md.

Thanks to @AkiraVoid for the clear bug report.

---
This change was prepared with AI assistance and reviewed by me before submission.