### PR TITLE
Fix dictionary mutation during filter lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Avoid mutating dictionaries while evaluating extended filter expressions.
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -14,7 +14,7 @@
 import operator
 import re
 
-from .. import JSONPath, DatumInContext, Index
+from .. import JSONPath, DatumInContext, Fields, Index
 
 
 OPERATOR_MAP = {
@@ -42,25 +42,28 @@ class Filter(JSONPath):
         datum = DatumInContext.wrap(datum)
 
         if isinstance(datum.value, dict):
-            datum.value = list(datum.value.values())
-
-        if not isinstance(datum.value, list):
+            candidates = [
+                DatumInContext(value, path=Fields(key), context=datum)
+                for key, value in datum.value.items()
+            ]
+        elif isinstance(datum.value, list):
+            candidates = [
+                DatumInContext(value, path=Index(index), context=datum)
+                for index, value in enumerate(datum.value)
+            ]
+        else:
             return []
 
-        return [DatumInContext(datum.value[i], path=Index(i), context=datum)
-                for i in range(0, len(datum.value))
+        return [candidate for candidate in candidates
                 if (len(self.expressions) ==
-                    len(list(filter(lambda x: x.find(datum.value[i]),
+                    len(list(filter(lambda x: x.find(candidate.value),
                                     self.expressions))))]
 
     def filter(self, fn, data):
         # NOTE: We reverse the order just to make sure the indexes are preserved upon
         #  removal.
         for datum in reversed(self.find(data)):
-            index_obj = datum.path
-            if isinstance(data, dict):
-                index_obj.index = list(data)[index_obj.index]
-            index_obj.filter(fn, data)
+            datum.path.filter(fn, data)
         return data
 
     def update(self, data, val):

--- a/tests/test_jsonpath_rw_ext.py
+++ b/tests/test_jsonpath_rw_ext.py
@@ -5,6 +5,9 @@ test_jsonpath_ng_ext
 Tests for `jsonpath_ng_ext` module.
 """
 
+import copy
+from types import MappingProxyType
+
 import pytest
 
 from jsonpath_ng.exceptions import JsonPathParserError
@@ -504,6 +507,54 @@ test_cases = (
 def test_values(path, data, expected_values):
     results = parser.parse(path).find(data)
     assert_value_equality(results, expected_values)
+
+
+def test_filter_find_does_not_mutate_mapping():
+    source = {
+        "objects": {
+            "first": {"score": 90},
+            "second": {"score": 50},
+        }
+    }
+    original = copy.deepcopy(source)
+
+    matches = parser.parse("$.objects[?(@.score >= 85)]").find(source)
+
+    assert [match.value for match in matches] == [{"score": 90}]
+    assert [str(match.full_path) for match in matches] == ["(objects.first)"]
+    assert source == original
+
+    matches[0].value = {"score": 95}
+    assert source["objects"] == {
+        "first": {"score": 95},
+        "second": {"score": 50},
+    }
+
+
+def test_filter_find_accepts_read_only_mapping():
+    source = MappingProxyType(
+        {
+            "objects": {
+                "first": {"score": 90},
+                "second": {"score": 50},
+            }
+        }
+    )
+
+    matches = parser.parse("$.objects[?(@.score >= 85)]").find(source)
+
+    assert [match.value for match in matches] == [{"score": 90}]
+
+
+def test_filter_removes_matching_mapping_entries():
+    source = {
+        "first": {"score": 90},
+        "second": {"score": 50},
+    }
+
+    parser.parse("$[?(@.score >= 85)]").filter(lambda _: True, source)
+
+    assert source == {"second": {"score": 50}}
 
 
 def test_invalid_hyphenation_in_key():


### PR DESCRIPTION
Closes #214.

Build extended-filter candidates without assigning through `DatumInContext.value`. Dictionary candidates now retain their field paths, so `find()` leaves mutable and read-only mappings unchanged while later match updates and filter removals still address the original keys.

Tests: the full 354-test suite passes on Python 3.12, 3.13, and 3.14.
