### PR TITLE
Create paths through null intermediate fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Allow `find_or_create` and `update_or_create` to create paths through null intermediate fields.
+
 ## [1.8.0] - 2026-02-24
 
 ### Added

--- a/jsonpath_ng/jsonpath.py
+++ b/jsonpath_ng/jsonpath.py
@@ -270,6 +270,15 @@ class Child(JSONPath):
         self.left = left
         self.right = right
 
+    @staticmethod
+    def _prepare_for_create(datum):
+        if datum.value is None:
+            # A null intermediate cannot contain the remaining path. Treat it
+            # like a missing intermediate and let the next path segment choose
+            # whether the placeholder becomes a mapping or a list.
+            datum.value = {}
+        return datum
+
     def find(self, datum):
         """
         Extra special case: auto ids do not have children,
@@ -294,12 +303,14 @@ class Child(JSONPath):
                 # Extra special case: auto ids do not have children,
                 # so cut it off right now rather than auto id the auto id
                 continue
+            subdata = self._prepare_for_create(subdata)
             for submatch in self.right.find_or_create(subdata):
                 submatches.append(submatch)
         return submatches
 
     def update_or_create(self, data, val):
         for datum in self.left.find_or_create(data):
+            datum = self._prepare_for_create(datum)
             self.right.update_or_create(datum.value, val)
         return _clean_list_keys(data)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -11,7 +11,9 @@ from jsonpath_ng.ext import parse
     (
         ("$.foo", {}, {"foo": 42}),
         ("$.foo.bar", {}, {"foo": {"bar": 42}}),
+        ("$.foo.bar", {"foo": None}, {"foo": {"bar": 42}}),
         ("$.foo[0]", {}, {"foo": [42]}),
+        ("$.foo[0]", {"foo": None}, {"foo": [42]}),
         ("$.foo[1]", {}, {"foo": [{}, 42]}),
         ("$.foo[0].bar", {}, {"foo": [{"bar": 42}]}),
         ("$.foo[1].bar", {}, {"foo": [{}, {"bar": 42}]}),
@@ -46,6 +48,26 @@ def test_update_or_create(string, initial_data, expected_result):
     jsonpath = parse(string)
     result = jsonpath.update_or_create(initial_data, 42)
     assert result == expected_result
+
+
+def test_find_or_create_replaces_null_intermediate_fields():
+    data = {"folder": {"document": None}}
+    jsonpath = parse("$.folder.document.doc_a.value")
+
+    matches = jsonpath.find_or_create(data)
+
+    assert [match.value for match in matches] == [{}]
+    assert data == {"folder": {"document": {"doc_a": {"value": {}}}}}
+
+
+@pytest.mark.parametrize("value", (False, 0, "", []))
+def test_update_or_create_does_not_replace_non_null_intermediates(value):
+    data = {"foo": value}
+
+    with pytest.raises(TypeError):
+        parse("$.foo.bar").update_or_create(data, 42)
+
+    assert data == {"foo": value}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #218.

- Treat `None` intermediate fields like missing path containers.
- Share the behavior across `find_or_create` and `update_or_create`.
- Preserve existing failures for non-null scalar intermediates.

Tests: 358 passing on Python 3.12, 3.13, and 3.14.
